### PR TITLE
Fix bug in dynare_estimation_init.m if steady state does not solve

### DIFF
--- a/matlab/dynare_estimation_1.m
+++ b/matlab/dynare_estimation_1.m
@@ -107,29 +107,6 @@ if options_.dsge_var
     end
 end
 
-%check for calibrated covariances before updating parameters
-if ~isempty(estim_params_)
-    estim_params_=check_for_calibrated_covariances(xparam1,estim_params_,M_);
-end
-
-%%read out calibration that was set in mod-file and can be used for initialization
-xparam1_calib=get_all_parameters(estim_params_,M_); %get calibrated parameters
-if ~any(isnan(xparam1_calib)) %all estimated parameters are calibrated
-    full_calibration_detected=1;
-else
-    full_calibration_detected=0;
-end
-if options_.use_calibration_initialization %set calibration as starting values
-    [xparam1,estim_params_]=do_parameter_initialization(estim_params_,xparam1_calib,xparam1);   %get explicitly initialized parameters that have precedence to calibrated values
-    try
-        check_prior_bounds(xparam1,bounds,M_,estim_params_,options_,bayestopt_); %check whether calibration satisfies prior bounds
-    catch
-        e = lasterror();
-        fprintf('Cannot use parameter values from calibration as they violate the prior bounds.')
-        rethrow(e);
-    end
-end
-
 % Set sigma_e_is_diagonal flag (needed if the shocks block is not declared in the mod file).
 M_.sigma_e_is_diagonal = 1;
 if estim_params_.ncx || any(nnz(tril(M_.Correlation_matrix,-1))) || isfield(estim_params_,'calibrated_covariances')
@@ -180,7 +157,7 @@ try
     oo_ = initial_estimation_checks(objective_function,xparam1,dataset_,dataset_info,M_,estim_params_,options_,bayestopt_,bounds,oo_);
 catch % if check fails, provide info on using calibration if present
     e = lasterror();
-    if full_calibration_detected %calibrated model present and no explicit starting values
+    if estim_params_.full_calibration_detected %calibrated model present and no explicit starting values
         skipline(1);
         fprintf('ESTIMATION_CHECKS: There was an error in computing the likelihood for initial parameter values.\n')
         fprintf('ESTIMATION_CHECKS: You should try using the calibrated version of the model as starting values. To do\n')

--- a/matlab/dynare_estimation_init.m
+++ b/matlab/dynare_estimation_init.m
@@ -281,6 +281,22 @@ if ~isempty(estim_params_) && ~isempty(options_.mode_file) && ~options_.mh_poste
     skipline()
 end
 
+%check for calibrated covariances before updating parameters
+if ~isempty(estim_params_)
+    estim_params_=check_for_calibrated_covariances(xparam1,estim_params_,M_);
+end
+
+%%read out calibration that was set in mod-file and can be used for initialization
+xparam1_calib=get_all_parameters(estim_params_,M_); %get calibrated parameters
+if ~any(isnan(xparam1_calib)) %all estimated parameters are calibrated
+    estim_params_.full_calibration_detected.full_calibration_detected=1;
+else
+    estim_params_.full_calibration_detected.full_calibration_detected=0;
+end
+if options_.use_calibration_initialization %set calibration as starting values
+    [xparam1,estim_params_]=do_parameter_initialization(estim_params_,xparam1_calib,xparam1); %get explicitly initialized parameters that have precedence to calibrated values
+end
+
 if ~isempty(estim_params_) 
     if ~isempty(bayestopt_) && any(bayestopt_.pshape > 0)
         % Plot prior densities.
@@ -299,7 +315,17 @@ if ~isempty(estim_params_)
         bounds.ub = ub;
     end
     % Test if initial values of the estimated parameters are all between the prior lower and upper bounds.
-    check_prior_bounds(xparam1,bounds,M_,estim_params_,options_,bayestopt_)
+    if options_.use_calibration_initialization
+        try
+            check_prior_bounds(xparam1,bounds,M_,estim_params_,options_,bayestopt_)
+        catch
+            e = lasterror();
+            fprintf('Cannot use parameter values from calibration as they violate the prior bounds.')
+            rethrow(e);
+        end
+    else
+        check_prior_bounds(xparam1,bounds,M_,estim_params_,options_,bayestopt_)
+    end        
 end
 
 if isempty(estim_params_)% If estim_params_ is empty (e.g. when running the smoother on a calibrated model)
@@ -514,7 +540,13 @@ ncn = estim_params_.ncn;
 if estim_params_.np
   M.params(estim_params_.param_vals(:,1)) = xparam1(nvx+ncx+nvn+ncn+1:end);
 end
-[oo_.steady_state, params] = evaluate_steady_state(oo_.steady_state,M,options_,oo_,steadystate_check_flag);
+[oo_.steady_state, params,info] = evaluate_steady_state(oo_.steady_state,M,options_,oo_,steadystate_check_flag);
+
+if info(1)
+    fprintf('\ndynare_estimation_init:: The steady state at the initial parameters cannot be computed.')
+    print_info(info, 0, options_);
+end
+
 if all(abs(oo_.steady_state(bayestopt_.mfys))<1e-9)
     options_.noconstant = 1;
 else


### PR DESCRIPTION
There was no check in dynare_estimation_init.m whether the steady state solved, but the noconstant option was set nevertheless. This gave rise to cases where a steady state file returned 0 for the observables, but the steady state did not exits. Due to later using use_calibration, this problem with the initial values was not detected, but the observation equation featured no constant although it should. The solution is to move the use_calibration option before the first steady state computation and then issue an error if the parameterization does not work