### PR TITLE
Fix bug in pm3 for filtered variables that led to crashes

### DIFF
--- a/matlab/pm3.m
+++ b/matlab/pm3.m
@@ -65,7 +65,7 @@ k = 0;
 filter_step_ahead_indicator=0;
 for file = 1:ifil
     load([DirectoryName '/' M_.fname var_type int2str(file)]);
-    if size(size(stock),2) == 4
+    if strcmp(var_type,'_filter_step_ahead')
         if file==1 %on first run, initialize variable for storing filter_step_ahead
             stock1_filter_step_ahead=NaN(n1,n2,B,length(options_.filter_step_ahead)); 
         end


### PR DESCRIPTION
Check for size of array failed with singleton dimension