### PR TITLE
Fix and document relative_irf

### DIFF
--- a/doc/dynare.texi
+++ b/doc/dynare.texi
@@ -3663,8 +3663,12 @@ suppresses the plotting of IRFs. Default: @code{40}.
 The exogenous variables for which to compute IRFs. Default: all.
 
 @item relative_irf
-Requests the computation of normalized IRFs in percentage of the
-standard error of each shock.
+@anchor{relative_irf}
+
+Requests the computation of normalized IRFs. At first order, the normal shock vector of size one standard deviation is divided by the standard deviation of the current shock and multiplied by 100. The impulse responses are hence the responses to a unit shock of size 1 (as opposed to the regular shock size of one standard deviation), multiplied by 100. Thus, for a loglinearized model where the variables are measured in percent, the IRFs have the interpretation of the percent responses to a 100 percent shock. For example, a response of 400 of output to a TFP shock shows that output increases by 400 percent after a 100 percent TFP shock (you will see that TFP increases by 100 on impact). Given linearity at @code{ordeR=1}, it is straightforward to rescale the IRFs stored in @code{oo_.irfs} to any desired size.
+At higher order, the interpretation is different. The @code{relative_irf} option then triggers the generation of IRFs as the response to a 0.01 unit shock (corresponding to 1 percent for shocks measured in percent) and no multiplication with 100 is performed. That is, the normal shock vector of size one standard deviation is divided by the standard deviation of the current shock and divided by 100.
+For example, a response of 0.04 of log output (thus measured in percent of the steady state output level) to a TFP shock also measured in percent then shows that output increases by 4 percent after a 1 percent TFP shock (you will see that TFP increases by 0.01 on impact).
+
 
 @item irf_plot_threshold = @var{DOUBLE}
 @anchor{irf_plot_threshold}
@@ -5228,6 +5232,9 @@ Metropolis-Hastings. Default: diagnostics are computed and displayed
 distribution of IRFs. The length of the IRFs are controlled by the
 @code{irf} option. Results are stored in @code{oo_.PosteriorIRF.dsge}
 (see below for a description of this variable)
+
+@item relative_irf
+@xref{relative_irf}.
 
 @item dsge_var = @var{DOUBLE}
 @anchor{dsge_var} Triggers the estimation of a DSGE-VAR model, where the

--- a/matlab/PosteriorIRF_core1.m
+++ b/matlab/PosteriorIRF_core1.m
@@ -177,8 +177,12 @@ while fpar<B
     irf_shocks_indx = getIrfShocksIndx();
     for i=irf_shocks_indx
         if SS(i,i) > 1e-13
-            y=irf(dr,SS(M_.exo_names_orig_ord,i), options_.irf, options_.drop,options_.replic,options_.order);
-            if options_.relative_irf
+            if options_.order>1 && options_.relative_irf % normalize shock to 0.01 before IRF generation for GIRFs; multiply with 100 later
+                y=irf(dr,SS(M_.exo_names_orig_ord,i)./SS(i,i)/100, options_.irf, options_.drop,options_.replic,options_.order);
+            else
+                y=irf(dr,SS(M_.exo_names_orig_ord,i), options_.irf, options_.drop,options_.replic,options_.order);
+            end
+            if options_.relative_irf && options_.order==1 %multiply with 100 for backward compatibility
                 y = 100*y/SS(i,i);
             end
             for j = 1:nvar

--- a/matlab/stoch_simul.m
+++ b/matlab/stoch_simul.m
@@ -186,8 +186,13 @@ if options_.irf
             if PI_PCL_solver
                 y=PCL_Part_info_irf (0, PCL_varobs, i_var, M_, oo_.dr, options_.irf, i);
             else
-                y=irf(oo_.dr,cs(M_.exo_names_orig_ord,i), options_.irf, options_.drop, ...
-                      options_.replic, options_.order);
+                if options_.order>1 && options_.relative_irf % normalize shock to 0.01 before IRF generation for GIRFs; multiply with 100 later
+                    y=irf(oo_.dr,cs(M_.exo_names_orig_ord,i)./cs(i,i)/100, options_.irf, options_.drop, ...
+                          options_.replic, options_.order);                
+                else %for linear model, rescaling is done later
+                    y=irf(oo_.dr,cs(M_.exo_names_orig_ord,i), options_.irf, options_.drop, ...
+                          options_.replic, options_.order);
+                end
             end
             if ~options_.noprint && any(any(isnan(y))) && ~options_.pruning && ~(options_.order==1)
                 fprintf('\nstoch_simul:: The simulations conducted for generating IRFs to %s were explosive.\n',M_.exo_names(i,:))
@@ -196,7 +201,9 @@ if options_.irf
                 skipline(2);
             end
             if options_.relative_irf
-                y = 100*y/cs(i,i);
+                if options_.order==1 %multiply with 100 for backward compatibility
+                    y = 100*y/cs(i,i);
+                end
             end
             irfs   = [];
             mylist = [];

--- a/preprocessor/DynareBison.yy
+++ b/preprocessor/DynareBison.yy
@@ -1658,6 +1658,7 @@ estimation_options : o_datafile
                    | o_nodecomposition
                    | o_nodiagnostic
                    | o_bayesian_irf
+                   | o_relative_irf
                    | o_dsge_var
                    | o_dsge_varlag
                    | o_irf

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -18,6 +18,7 @@ MODFILES = \
 	example1_abs_sign.mod \
 	example1_macroif.mod \
 	t_sgu_ex1.mod \
+	irfs/example1_unit_std.mod \
 	optimal_policy/osr_example.mod \
 	optimal_policy/osr_example_objective_correctness.mod \
 	optimal_policy/osr_example_obj_corr_non_stat_vars.mod \

--- a/tests/irfs/example1_unit_std.mod
+++ b/tests/irfs/example1_unit_std.mod
@@ -1,0 +1,103 @@
+/*
+ * Example 1 from F. Collard (2001): "Stochastic simulations with DYNARE:
+ * A practical guide" (see "guide.pdf" in the documentation directory).
+ */
+
+/*
+ * Copyright (C) 2001-2010 Dynare Team
+ *
+ * This file is part of Dynare.
+ *
+ * Dynare is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Dynare is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Dynare.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+var y, c, k, a, h, b;
+varexo e, u;
+
+parameters beta, rho, alpha, delta, theta, psi, tau;
+
+alpha = 0.36;
+rho   = 0.95;
+tau   = 0.025;
+beta  = 0.99;
+delta = 0.025;
+psi   = 0;
+theta = 2.95;
+
+phi   = 0.1;
+
+model;
+c*theta*h^(1+psi)=(1-alpha)*y;
+k = beta*(((exp(b)*c)/(exp(b(+1))*c(+1)))
+    *(exp(b(+1))*alpha*y(+1)+(1-delta)*k));
+y = exp(a)*(k(-1)^alpha)*(h^(1-alpha));
+k = exp(b)*(y-c)+(1-delta)*k(-1);
+a = rho*a(-1)+tau*b(-1) + e;
+b = tau*a(-1)+rho*b(-1) + u;
+end;
+
+initval;
+y = 1.08068253095672;
+c = 0.80359242014163;
+h = 0.29175631001732;
+k = 11.08360443260358;
+a = 0;
+b = 0;
+e = 0;
+u = 0;
+end;
+
+shocks;
+var e; stderr 1;
+var u; stderr 1;
+end;
+
+stoch_simul(irf=20,order=1);
+unit_irf=cell2mat(struct2cell(oo_.irfs));
+
+shocks;
+var e; stderr 0.005;
+var u; stderr 0.005;
+end;
+
+stoch_simul(irf=20,order=1,relative_irf);
+relative_irfs=cell2mat(struct2cell(oo_.irfs));
+if max(max(abs(100*unit_irf-relative_irfs)))>1e-8;
+     error('relative_irf-option at order=1 is broken')
+end
+
+
+//Check relative IRF option at order 2 by comparing it with unnormalized IRF of unit size 
+shocks;
+var e; stderr 0.01;
+var u; stderr 0.01;
+end;
+set_dynare_seed('default');
+options_.relative_irf=0;
+stoch_simul(irf=20,order=2);
+unit_irf_order_2=cell2mat(struct2cell(oo_.irfs));
+
+shocks;
+var e; stderr 0.0095;
+var u; stderr 0.0095;
+end;
+set_dynare_seed('default');
+stoch_simul(irf=20,order=2,relative_irf);
+relative_irfs_order_2=cell2mat(struct2cell(oo_.irfs));
+if max(max(abs(unit_irf_order_2-relative_irfs_order_2)))>1e-4;
+     error('relative_irf-option at order=2 is broken')
+end
+
+             


### PR DESCRIPTION
- at higher order the normalization is invalid as it relies on linearity
- the manual entry was cryptic
- allows for explicit use of relative_irf option in estimation command instead of only inheriting it via stoch_simul
- Adds unit test