### PR TITLE
Integrate error from negative steady state with loglinear model into pri...

### DIFF
--- a/matlab/dsge_likelihood.m
+++ b/matlab/dsge_likelihood.m
@@ -70,6 +70,8 @@ function [fval,DLIK,Hess,exit_flag,SteadyState,trend_coeff,info,Model,DynareOpti
 %! M_.params has been updated in the steadystate routine and has complex valued scalars.
 %! @item info==24
 %! M_.params has been updated in the steadystate routine and has some NaNs.
+%! @item info==26
+%! M_.params has been updated in the steadystate routine and has negative/0 values in loglinear model.
 %! @item info==30
 %! Ergodic variance can't be computed.
 %! @item info==41
@@ -266,7 +268,7 @@ if info(1) == 1 || info(1) == 2 || info(1) == 5 || info(1) == 7 || info(1) == 8 
         DLIK=ones(length(xparam1),1);
     end
     return
-elseif info(1) == 3 || info(1) == 4 || info(1)==6 || info(1) == 20 || info(1) == 21  || info(1) == 23
+elseif info(1) == 3 || info(1) == 4 || info(1)==6 || info(1) == 20 || info(1) == 21  || info(1) == 23 || info(1)==26
     fval = objective_function_penalty_base+info(2);
     info = info(1);
     exit_flag = 0;

--- a/matlab/print_info.m
+++ b/matlab/print_info.m
@@ -88,6 +88,8 @@ if ~noprint
         error('Some updated params contain NaN or Inf')
       case 25
         error('The solution to the static equations is not a steady state of the dynamic model: verify that the equations tagged by [static] and [dynamic] are consistent')
+      case 26
+        error('The loglinearization of the model cannot be performed, because the steady state is not strictly positive.')
       case 30
         error('Variance can''t be computed')
       case 41

--- a/matlab/resol.m
+++ b/matlab/resol.m
@@ -111,23 +111,27 @@ if options.loglinear
     % Find variables with non positive steady state.
     idx = find(dr.ys<1e-9);
     if length(idx)
-        variables_with_non_positive_steady_state = M.endo_names(idx,:);
-        skipline()
-        fprintf('You are attempting to simulate/estimate a loglinear approximation of a model, but\n')
-        fprintf('the steady state level of the following variables is not strictly positive:\n')
-        for var_iter=1:length(idx)
-            fprintf(' - %s (%s)\n',deblank(variables_with_non_positive_steady_state(var_iter,:)), num2str(dr.ys(idx(var_iter))))
+        if options.debug
+            variables_with_non_positive_steady_state = M.endo_names(idx,:);
+            skipline()
+            fprintf('You are attempting to simulate/estimate a loglinear approximation of a model, but\n')
+            fprintf('the steady state level of the following variables is not strictly positive:\n')
+            for var_iter=1:length(idx)
+                fprintf(' - %s (%s)\n',deblank(variables_with_non_positive_steady_state(var_iter,:)), num2str(dr.ys(idx(var_iter))))
+            end
+            if isestimation()
+                fprintf('You should check that the priors and/or bounds over the deep parameters are such\n')
+                fprintf('that the steady state levels of all the variables are strictly positive, or consider\n')
+                fprintf('a linearization of the model instead of a log linearization.\n')
+            else
+                fprintf('You should check that the calibration of the deep parameters is such that the\n')
+                fprintf('steady state levels of all the variables are strictly positive, or consider\n')
+                fprintf('a linearization of the model instead of a log linearization.\n')
+            end
         end
-        if isestimation()
-            fprintf('You should check that the priors and/or bounds over the deep parameters are such\n')
-            fprintf('that the steady state levels of all the variables are strictly positive, or consider\n')
-            fprintf('a linearization of the model instead of a log linearization.\n')
-        else
-            fprintf('You should check that the calibration of the deep parameters is such that the\n')
-            fprintf('steady state levels of all the variables are strictly positive, or consider\n')
-            fprintf('a linearization of the model instead of a log linearization.\n')
-        end
-        error('stoch_simul::resol: The loglinearization of the model cannot be performed, because the steady state is not strictly positive!')
+        info(1)=26;
+        info(2)=sum(dr.ys(dr.ys<1e-9).^2);
+        return
     end
 end
 


### PR DESCRIPTION
...nt_info.m

Prevents crashes during estimation (as in unit test). Instead of directly crashing, error handling is done via print_info.m so that penalizing the error during estimation is possible