### PR TITLE
Fixed issues related to newratflag.

### DIFF
--- a/doc/dynare.texi
+++ b/doc/dynare.texi
@@ -4855,7 +4855,9 @@ Uses Chris Sims's @code{csminwel}
 
 @item 5
 Uses Marco Ratto's @code{newrat}. This value is not compatible with non
-linear filters or DSGE-VAR models
+linear filters or DSGE-VAR models.
+This is a slice optimizer: most iterations are a sequence of univariate optimization step, one for each estimated parameter or shock.
+Uses @code{csminwel} for line search in each step.
 
 @item 6
 Uses a Monte-Carlo based optimization routine (see
@@ -4971,6 +4973,25 @@ Stopping criteria. Default: @code{1e-7}
 
 @item 'InitialInverseHessian'
 Initial approximation for the inverse of the Hessian matrix of the posterior kernel (or likelihood). Obviously this approximation has to be a square, positive definite and symmetric matrix. Default: @code{'1e-4*eye(nx)'}, where @code{nx} is the number of parameters to be estimated.
+
+@end table
+
+@item 5
+Available options are:
+
+@table @code
+
+@item 'MaxIter'
+Maximum number of iterations. Default: @code{1000}
+
+@item 'Hessian'
+Triggers three types of Hessian computations. @code{0}: outer product gradient; @code{1} default DYNARE Hessian routine; @code{2} 'mixed' outer product gradient, where diagonal elements are obtained using second order derivation formula and outer product is used for correlation structure. 
+Both @{0} and @{2} options require univariate filters, to ensure using maximum number of individual densities and a positive definite Hessian.
+Both @{0} and @{2} are quicker than default DYNARE numeric Hessian, but provide decent starting values for Metropolis for large models (option @{2} being more accurate than @{0}).
+Default: @code{1}.
+
+@item 'TolFun'
+Stopping criteria. Default: @code{1e-5} for numerical derivatives @code{1e-7} for analytic derivatives.
 
 @end table
 

--- a/matlab/global_initialization.m
+++ b/matlab/global_initialization.m
@@ -481,7 +481,7 @@ csminwel.maxiter=1000;
 options_.csminwel=csminwel;
 
 %newrat optimization routine
-newrat.hess=1; %analytic hessian
+newrat.hess=1; % dynare numerical hessian
 newrat.tolerance.f=1e-5;
 newrat.tolerance.f_analytic=1e-7;
 newrat.maxiter=1000;

--- a/matlab/optimization/dynare_minimize_objective.m
+++ b/matlab/optimization/dynare_minimize_objective.m
@@ -177,10 +177,9 @@ switch minimizer_algorithm
         end
     end
     [opt_par_values,hessian_mat,gg,fval,invhess] = newrat(objective_function,start_par_value,analytic_grad,crit,nit,0,varargin{:});
+    %hessian_mat is the plain outer product gradient Hessian
     if options_.analytic_derivation %Hessian is already analytic one, reset option
         options_.analytic_derivation = ana_deriv;
-    elseif ~options_.analytic_derivation && newratflag ==0 %Analytic Hessian wanted, but not computed yet
-            hessian_mat = reshape(mr_hessian(0,opt_par_values,objective_function,1,crit,varargin{:}), n_params, n_params);
     end
   case 6
     [opt_par_values, hessian_mat, Scale, fval] = gmhmaxlik(objective_function, start_par_value, ...


### PR DESCRIPTION
This option relates to alternative numerical hessian computations:

optim=('Hessian',1) is the default dynare numeric Hessian
optim=('Hessian',0) is the outer product gradient
optim=('Hessian',2) is the 'mixed' outer product gradient, where diagonal elements are obtained using second order derivation formula and outer product is used for correlation structure.

Both 0 and 2 cases require univariate filters, to ensure using maximum number of individual densities.
Both 0 and 2 are quicker than default dynare numeric Hessian, but provide decent starting values for Metropolis for large models (option 2 being the best out of the two options)