### PR TITLE
Change call to test.m to fataltest.m

### DIFF
--- a/tests/deterministic_simulations/rbc_det_exo_lag_2b.mod
+++ b/tests/deterministic_simulations/rbc_det_exo_lag_2b.mod
@@ -77,4 +77,4 @@ rplot Capital;
 
 O=load('rbc_det_exo_lag_2a_results');
 
-test(oo_.endo_simul(:,2:end),O.oo_.endo_simul);
+fataltest(oo_.endo_simul(:,2:end),O.oo_.endo_simul);

--- a/tests/deterministic_simulations/rbc_det_exo_lag_2c.mod
+++ b/tests/deterministic_simulations/rbc_det_exo_lag_2c.mod
@@ -77,4 +77,4 @@ rplot Capital;
 
 O=load('rbc_det_exo_lag_2a_results');
 
-test(oo_.endo_simul(:,2:end),O.oo_.endo_simul);
+fataltest(oo_.endo_simul(:,2:end),O.oo_.endo_simul);


### PR DESCRIPTION
Necessary after a988418668cb8d8441c5c483700f03bea9c685f9 to prevent crashes