### PR TITLE
Diffuse filter and smoother

### DIFF
--- a/matlab/DsgeSmoother.m
+++ b/matlab/DsgeSmoother.m
@@ -69,9 +69,10 @@ M_ = set_all_parameters(xparam1,estim_params_,M_);
 %------------------------------------------------------------------------------
 % 2. call model setup & reduction program
 %------------------------------------------------------------------------------
-oo_.dr.restrict_var_list = bayestopt_.smoother_var_list;
-oo_.dr.restrict_columns = bayestopt_.smoother_restrict_columns;
-[T,R,SteadyState,info,M_,options_,oo_] = dynare_resolve(M_,options_,oo_);
+DynareResults = oo_;
+DynareResults.dr.restrict_var_list = bayestopt_.smoother_var_list;
+DynareResults.dr.restrict_columns = bayestopt_.smoother_restrict_columns;
+[T,R,SteadyState,info,M_,options_,DynareResults] = dynare_resolve(M_,options_,DynareResults);
 bayestopt_.mf = bayestopt_.smoother_mf;
 if options_.noconstant
     constant = zeros(vobs,1);

--- a/matlab/kalman/likelihood/kalman_filter_d.m
+++ b/matlab/kalman/likelihood/kalman_filter_d.m
@@ -59,8 +59,9 @@ dlik = zeros(smpl,1);      % Initialization of the vector gathering the densitie
 dLIK = Inf;                % Default value of the log likelihood.
 oldK = Inf;
 s    = 0;
+crit1=1.e-6;
 
-while rank(Pinf,kalman_tol) && (t<=last)
+while rank(Pinf,crit1) && (t<=last)
     s = t-start+1;
     v = Y(:,t)-Z*a;
     Finf  = Z*Pinf*Z';

--- a/matlab/kalman/likelihood/missing_observations_kalman_filter_d.m
+++ b/matlab/kalman/likelihood/missing_observations_kalman_filter_d.m
@@ -66,13 +66,14 @@ t    = start;              % Initialization of the time index.
 dlik = zeros(smpl,1);      % Initialization of the vector gathering the densities.
 dLIK = Inf;                % Default value of the log likelihood.
 oldK = Inf;
+crit1=1.e-6;
 
 if isequal(H,0)
     H = zeros(pp,pp);
 end
 s = 0;
 
-while rank(Pinf,kalman_tol) && (t<=last)
+while rank(Pinf,crit1) && (t<=last)
     s = t-start+1;
     d_index = data_index{t};
     if isempty(d_index)

--- a/matlab/kalman/likelihood/univariate_kalman_filter_d.m
+++ b/matlab/kalman/likelihood/univariate_kalman_filter_d.m
@@ -110,7 +110,8 @@ dLIK = Inf;                % Default value of the log likelihood.
 oldK = Inf;
 llik = zeros(smpl,pp);
 
-newRank = rank(Pinf,kalman_tol);
+crit1 = 1.e-6;
+newRank = rank(Pinf,crit1);
 l2pi = log(2*pi);
 
 while newRank && (t<=last)
@@ -138,7 +139,7 @@ while newRank && (t<=last)
         end
     end
     if newRank
-        oldRank = rank(Pinf,kalman_tol);
+        oldRank = rank(Pinf,crit1);
     else
         oldRank = 0;
     end
@@ -146,7 +147,7 @@ while newRank && (t<=last)
     Pstar = T*Pstar*T'+QQ;
     Pinf  = T*Pinf*T';
     if newRank
-        newRank = rank(Pinf,kalman_tol);
+        newRank = rank(Pinf,crit1);
     end
     if oldRank ~= newRank
         disp('univariate_diffuse_kalman_filter:: T does influence the rank of Pinf!')


### PR DESCRIPTION
- harmonize tolerance criteria for diffuse likelihood to diffuse smoother
- avoid overwriting global restrict var list in smoother
- fix numerical issues in `schur_statespace_transformation`