### PR TITLE
Add functionality Prior posterior function

### DIFF
--- a/doc/dynare.texi
+++ b/doc/dynare.texi
@@ -12614,6 +12614,38 @@ Baseline New Keynesian Model estimated in @cite{Fernández-Villaverde (2010)}. I
 @node Dynare misc commands
 @chapter Dynare misc commands
 
+@anchor{prior_posterior_function}
+@deffn {MATLAB/Octave command} @var{output_cell_name}=prior_posterior_function('@var{function_name_string}','@var{prior_posterior_selector}',@var{OPTIONS})
+Executes a user-defined function on parameter draws from the prior or posterior distribution. The function 
+provided using the @var{function_name_string} must have the following header
+@code{output_cell =FILENAME(xparam1,M_,options_,oo_,estim_params_,bayestopt_,dataset_,dataset_info)}. 
+It allows read-only access to all Dynare structures. The only output argument allowed is a 1 by n cell array, 
+which allows for storing any type of output/computations. Dynare returns the results of the 
+computations for all draws in a ndraws by n cell array named @var{output_cell_name}.
+
+@optionshead
+
+@table @code
+
+@item prior_posterior_selector 
+
+Available options are
+@table @code
+
+@item 'prior'
+Executes the user-defined function on draws from the prior
+
+@item 'posterior'
+Executes the user-defined function on draws from the posterior
+
+@end table
+
+@item prior_posterior_sampling_draws
+Number of draws used for sampling. Default: 500.
+
+@end table
+
+
 @anchor{internals}
 @deffn {MATLAB/Octave command} internals @var{FLAG} @var{ROUTINENAME}[.m]|@var{MODFILENAME}
 

--- a/matlab/CutSample.m
+++ b/matlab/CutSample.m
@@ -1,12 +1,14 @@
 function CutSample(M_, options_, estim_params_)
-
-% function CutSample()
-% Takes a subset from metropolis
+% function CutSample(M_, options_, estim_params_)
+% Takes a subset from metropolis draws by storing the required information
+% like the first MH-file to be loaded and the first line in that file to be
+% loaded into the record structure saved on harddisk into the
+% _mh_history-file
 %
 % INPUTS
-%   options_         [structure]
-%   estim_params_    [structure]
-%   M_               [structure]
+%   M_               [structure]    Dynare model structure
+%   options_         [structure]    Dynare options structure
+%   estim_params_    [structure]    Parameter structure
 %
 % OUTPUTS
 %    none
@@ -14,7 +16,7 @@ function CutSample(M_, options_, estim_params_)
 % SPECIAL REQUIREMENTS
 %    none
 
-% Copyright (C) 2005-2012 Dynare Team
+% Copyright (C) 2005-2015 Dynare Team
 %
 % This file is part of Dynare.
 %

--- a/matlab/GetOneDraw.m
+++ b/matlab/GetOneDraw.m
@@ -1,20 +1,19 @@
 function [xparams, logpost] = GetOneDraw(type)
-
 % function [xparams, logpost] = GetOneDraw(type)
-% draws one row from metropolis
+% draws one parameter vector and its posterior from MCMC or the prior
 %
 % INPUTS
-%    type:      posterior
-%               prior
+%    type:      [string]       'posterior': draw from MCMC draws
+%                              'prior': draw from prior
 %        
 % OUTPUTS
-%    xparams:   vector of estimated parameters (drawn from posterior distribution)
-%    logpost:   log of the posterior density relative to this row
+%    xparams:   vector of estimated parameters (drawn from posterior or prior distribution)
+%    logpost:   log of the posterior density of this parameter vector
 %        
 % SPECIAL REQUIREMENTS
 %    none
 
-% Copyright (C) 2005-2011 Dynare Team
+% Copyright (C) 2005-2015 Dynare Team
 %
 % This file is part of Dynare.
 %
@@ -36,5 +35,7 @@ switch type
     [xparams, logpost] = metropolis_draw(0);
   case 'prior'
     xparams = prior_draw(0);
-    logpost = evaluate_posterior_kernel(xparams');
+    if nargout>1
+        logpost = evaluate_posterior_kernel(xparams');
+    end
 end

--- a/matlab/dynare_estimation_1.m
+++ b/matlab/dynare_estimation_1.m
@@ -450,7 +450,7 @@ if (any(bayestopt_.pshape  >0 ) && options_.mh_replic) || ...
         if ~options_.nodiagnostic && options_.mh_replic>0
             oo_= McMCDiagnostics(options_, estim_params_, M_,oo_);
         end
-        %% Here i discard first half of the draws:
+        %% Here I discard first mh_drop percent of the draws:
         CutSample(M_, options_, estim_params_);
         %% Estimation of the marginal density from the Mh draws:
         if options_.mh_replic
@@ -467,7 +467,7 @@ if (any(bayestopt_.pshape  >0 ) && options_.mh_replic) || ...
         else
             load([M_.fname '_results'],'oo_');
         end
-        error_flag = metropolis_draw(1);
+        [error_flag,junk,options_]= metropolis_draw(1,options_,estim_params_,M_);
         if options_.bayesian_irf
             if error_flag
                 error('Estimation::mcmc: I cannot compute the posterior IRFs!')

--- a/matlab/execute_prior_posterior_function.m
+++ b/matlab/execute_prior_posterior_function.m
@@ -1,0 +1,91 @@
+function [results_cell] = execute_prior_posterior_function(posterior_function_name,M_,options_,oo_,estim_params_,bayestopt_,dataset_,dataset_info,type)
+%[results_cell] = execute_prior_posterior_function(functionhandle,M_,options_,oo_,dataset_,estim_params_,bayestopt_,type)% This function executes a given function on draws of the posterior or prior distribution 
+% Executes user provided function on prior or posterior draws
+% 
+% INPUTS
+%   functionhandle               Handle to the function to be executed
+%   M_           [structure]     Matlab's structure describing the Model (initialized by dynare, see @ref{M_}).
+%   options_     [structure]     Matlab's structure describing the options (initialized by dynare, see @ref{options_}).
+%   oo_          [structure]     Matlab's structure gathering the results (initialized by dynare, see @ref{oo_}).
+%   estim_params_[structure]     Matlab's structure describing the estimated_parameters (initialized by dynare, see @ref{estim_params_}).
+%   bayestopt_   [structure]     Matlab's structure describing the parameter options (initialized by dynare, see @ref{bayestopt_}).
+%   dataset_     [structure]     Matlab's structure storing the dataset
+%   dataset_info [structure]     Matlab's structure storing the information about the dataset
+%   type         [string]        'prior' or 'posterior'
+%
+%
+% OUTPUTS
+%   results_cell    [cell]     ndrawsx1 cell array storing the results
+%                                of the prior/posterior computations
+
+% Copyright (C) 2013 Dynare Team
+%
+% This file is part of Dynare.
+%
+% Dynare is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% Dynare is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with Dynare.  If not, see <http://www.gnu.org/licenses/>.
+
+[directory,basename,extension] = fileparts(posterior_function_name);
+if isempty(extension)
+    extension = '.m';
+end
+fullname = [basename extension];
+if ~strcmp(extension,'.m') %if not m-file
+    error('The Posterior Function is not an m-file.')
+elseif ~exist(fullname,'file') %if m-file, but does not exist
+    error(['The Posterior Function ', fullname ,' was not found. Check the spelling.']);
+end
+%Create function handle
+functionhandle=str2func(posterior_function_name);
+
+% Get informations about the _posterior_draws files.
+if strcmpi(type,'posterior')
+    %% discard first mh_drop percent of the draws:
+    CutSample(M_, options_, estim_params_);
+    %% initialize metropolis draws
+    [error_flag,junk,options_]= metropolis_draw(1,options_,estim_params_,M_);
+    if error_flag
+        error('EXECUTE_POSTERIOR_FUNCTION: The draws could not be initialized')
+    end
+    n_draws=options_.sub_draws;
+elseif strcmpi(type,'prior')
+    prior_draw(1);
+    n_draws=options_.prior_draws;
+else
+    error('EXECUTE_POSTERIOR_FUNCTION: Unknown type!')
+end
+
+%get draws for later use
+first_draw=GetOneDraw(type);
+parameter_mat=NaN(n_draws,length(first_draw));
+parameter_mat(1,:)=first_draw;
+for draw_iter=2:n_draws
+    parameter_mat(draw_iter,:) = GetOneDraw(type);
+end
+
+% get output size
+try
+    junk=functionhandle(parameter_mat(1,:),M_,options_,oo_,estim_params_,bayestopt_,dataset_,dataset_info);
+catch err
+    fprintf('\nEXECUTE_POSTERIOR_FUNCTION: Execution of prior/posterior function led to an error. Execution cancelled.\n')
+    rethrow(err)
+end
+
+%initialize cell with number of columns
+results_cell=cell(n_draws,size(junk,2));
+
+%% compute function on draws
+for draw_iter = 1:n_draws
+    M_ = set_all_parameters(parameter_mat(draw_iter,:),estim_params_,M_);
+    [results_cell(draw_iter,:)]=functionhandle(parameter_mat(draw_iter,:),M_,options_,oo_,estim_params_,bayestopt_,dataset_,dataset_info);
+end

--- a/matlab/execute_prior_posterior_function.m
+++ b/matlab/execute_prior_posterior_function.m
@@ -48,11 +48,13 @@ end
 %Create function handle
 functionhandle=str2func(posterior_function_name);
 
+n_draws=options_.prior_posterior_sampling_draws;
 % Get informations about the _posterior_draws files.
 if strcmpi(type,'posterior')
     %% discard first mh_drop percent of the draws:
     CutSample(M_, options_, estim_params_);
     %% initialize metropolis draws
+    options_.sub_draws=n_draws; %set draws for sampling; changed value is not returned to base workspace
     [error_flag,junk,options_]= metropolis_draw(1,options_,estim_params_,M_);
     if error_flag
         error('EXECUTE_POSTERIOR_FUNCTION: The draws could not be initialized')
@@ -60,7 +62,6 @@ if strcmpi(type,'posterior')
     n_draws=options_.sub_draws;
 elseif strcmpi(type,'prior')
     prior_draw(1);
-    n_draws=options_.prior_draws;
 else
     error('EXECUTE_POSTERIOR_FUNCTION: Unknown type!')
 end

--- a/matlab/global_initialization.m
+++ b/matlab/global_initialization.m
@@ -291,6 +291,9 @@ options_.xls_range = '';
 % Prior draws
 options_.prior_draws = 10000;
 
+% Prior posterior function sampling draws
+options_.prior_posterior_sampling_draws = 500;
+
 options_.forecast = 0;
 
 % Model

--- a/matlab/global_initialization.m
+++ b/matlab/global_initialization.m
@@ -28,10 +28,11 @@ function global_initialization()
 % You should have received a copy of the GNU General Public License
 % along with Dynare.  If not, see <http://www.gnu.org/licenses/>.
 
-global oo_ M_ options_ estim_params_ bayestopt_ estimation_info ex0_ ys0_
-
+global oo_ M_ options_ estim_params_ bayestopt_ estimation_info ex0_ ys0_ dataset_ dataset_info
 estim_params_ = [];
 bayestopt_ = [];
+dataset_=[];
+dataset_info=[];
 options_.datafile = '';
 options_.dirname = M_.fname;
 M_.dname = M_.fname;

--- a/matlab/prior_draw.m
+++ b/matlab/prior_draw.m
@@ -1,9 +1,17 @@
 function pdraw = prior_draw(init,uniform) % --*-- Unitary tests --*--
-% This function generate one draw from the joint prior distribution.
+% This function generate one draw from the joint prior distribution and
+% allows sampling uniformly from the prior support (uniform==1 when called with init==1)
 % 
 % INPUTS 
-%   o init             [integer]    scalar equal to 1 (first call) or 0.
-%   o uniform          [integer]    scalar equal to 1 (first call) or 0.
+%   o init             [integer]    scalar equal to: 
+%                                       1: first call to set up persistent variables 
+%                                             describing the prior
+%                                       0: subsequent call to get prior
+%                                               draw
+%   o uniform          [integer]    scalar used in initialization (init=1), equal to:
+%                                       1: sample uniformly from prior
+%                                           support (overwrites prior shape used for sampling within this function)
+%                                       0: sample from joint prior distribution
 %    
 % OUTPUTS 
 %   o pdraw            [double]     1*npar vector, draws from the joint prior density.
@@ -14,7 +22,9 @@ function pdraw = prior_draw(init,uniform) % --*-- Unitary tests --*--
 %
 % NOTE 1. Input arguments 1 an 2 are only needed for initialization.
 % NOTE 2. A given draw from the joint prior distribution does not satisfy BK conditions a priori.
-
+% NOTE 3. This code relies on bayestopt_ as created in the base workspace
+%           by the preprocessor (or as updated in subsequent pieces of code and handed to the base workspace)
+% 
 % Copyright (C) 2006-2015 Dynare Team
 %
 % This file is part of Dynare.
@@ -87,7 +97,7 @@ if nargin>0 && init
     else
         inverse_gamma_2_draws = 1;
     end
-    pdraw = zeros(number_of_estimated_parameters,1);
+    pdraw = NaN(number_of_estimated_parameters,1);
     return
 end
 

--- a/preprocessor/ModFile.cc
+++ b/preprocessor/ModFile.cc
@@ -566,14 +566,14 @@ ModFile::writeOutputFiles(const string &basename, bool clear_all, bool clear_glo
   if (clear_all)
     mOutputFile << "clear all" << endl;
   else if (clear_global)
-    mOutputFile << "clear M_ options_ oo_ estim_params_ bayestopt_ dataset_;" << endl;
+    mOutputFile << "clear M_ options_ oo_ estim_params_ bayestopt_ dataset_ dataset_info estimation_info ys0_ ex0_;" << endl;
 
   mOutputFile << "tic;" << endl
 	      << "% Save empty dates and dseries objects in memory." << endl
 	      << "dates('initialize');" << endl
 	      << "dseries('initialize');" << endl
 	      << "% Define global variables." << endl
-              << "global M_ oo_ options_ ys0_ ex0_ estimation_info" << endl
+              << "global M_ options_ oo_ estim_params_ bayestopt_ dataset_ dataset_info estimation_info ys0_ ex0_" << endl
               << "options_ = [];" << endl
               << "M_.fname = '" << basename << "';" << endl
               << "M_.dynare_version = '" << PACKAGE_VERSION << "';" << endl

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -239,6 +239,7 @@ MODFILES = \
 	optimizers/fs2000_w.mod \
 	differentiate_forward_vars/RBC_differentiate_forward.mod \
 	TeX/fs2000_corr_ME.mod \
+	prior_posterior_function/fs2000_prior_posterior_function \
 	reporting/example1.mod
 
 XFAIL_MODFILES = ramst_xfail.mod \
@@ -447,7 +448,9 @@ EXTRA_DIST = \
 	optimal_policy/Ramsey/find_c.m \
 	optimal_policy/Ramsey/oo_ramsey_policy_initval.mat \
 	optimizers/optimizer_function_wrapper.m \
-	optimizers/fs2000.common.inc
+	optimizers/fs2000.common.inc \
+	prior_posterior_function/posterior_function_demo
+
 
 TARGETS =
 

--- a/tests/prior_posterior_function/fs2000_prior_posterior_function.mod
+++ b/tests/prior_posterior_function/fs2000_prior_posterior_function.mod
@@ -1,0 +1,129 @@
+/*
+ * This file replicates the estimation of the cash in advance model described
+ * Frank Schorfheide (2000): "Loss function-based evaluation of DSGE models",
+ * Journal of Applied Econometrics, 15(6), 645-670.
+ *
+ * The data are in file "fsdat_simul.m", and have been artificially generated.
+ * They are therefore different from the original dataset used by Schorfheide.
+ *
+ * The equations are taken from J. Nason and T. Cogley (1994): "Testing the
+ * implications of long-run neutrality for monetary business cycle models",
+ * Journal of Applied Econometrics, 9, S37-S70.
+ * Note that there is an initial minus sign missing in equation (A1), p. S63.
+ *
+ * This implementation was written by Michel Juillard. Please note that the
+ * following copyright notice only applies to this Dynare implementation of the
+ * model.
+ */
+
+/*
+ * Copyright (C) 2004-2010 Dynare Team
+ *
+ * This file is part of Dynare.
+ *
+ * Dynare is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Dynare is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Dynare.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+var m P c e W R k d n l gy_obs gp_obs y dA;
+varexo e_a e_m;
+
+parameters alp bet gam mst rho psi del;
+
+alp = 0.33;
+bet = 0.99;
+gam = 0.003;
+mst = 1.011;
+rho = 0.7;
+psi = 0.787;
+del = 0.02;
+
+model;
+dA = exp(gam+e_a);
+log(m) = (1-rho)*log(mst) + rho*log(m(-1))+e_m;
+-P/(c(+1)*P(+1)*m)+bet*P(+1)*(alp*exp(-alp*(gam+log(e(+1))))*k^(alp-1)*n(+1)^(1-alp)+(1-del)*exp(-(gam+log(e(+1)))))/(c(+2)*P(+2)*m(+1))=0;
+W = l/n;
+-(psi/(1-psi))*(c*P/(1-n))+l/n = 0;
+R = P*(1-alp)*exp(-alp*(gam+e_a))*k(-1)^alp*n^(-alp)/W;
+1/(c*P)-bet*P*(1-alp)*exp(-alp*(gam+e_a))*k(-1)^alp*n^(1-alp)/(m*l*c(+1)*P(+1)) = 0;
+c+k = exp(-alp*(gam+e_a))*k(-1)^alp*n^(1-alp)+(1-del)*exp(-(gam+e_a))*k(-1);
+P*c = m;
+m-1+d = l;
+e = exp(e_a);
+y = k(-1)^alp*n^(1-alp)*exp(-alp*(gam+e_a));
+gy_obs = dA*y/y(-1);
+gp_obs = (P/P(-1))*m(-1)/dA;
+end;
+
+shocks;
+var e_a; stderr 0.014;
+var e_m; stderr 0.005;
+end;
+
+steady_state_model;
+  dA = exp(gam);
+  gst = 1/dA;
+  m = mst;
+  khst = ( (1-gst*bet*(1-del)) / (alp*gst^alp*bet) )^(1/(alp-1));
+  xist = ( ((khst*gst)^alp - (1-gst*(1-del))*khst)/mst )^(-1);
+  nust = psi*mst^2/( (1-alp)*(1-psi)*bet*gst^alp*khst^alp );
+  n  = xist/(nust+xist);
+  P  = xist + nust;
+  k  = khst*n;
+
+  l  = psi*mst*n/( (1-psi)*(1-n) );
+  c  = mst/P;
+  d  = l - mst + 1;
+  y  = k^alp*n^(1-alp)*gst^alp;
+  R  = mst/bet;
+  W  = l/n;
+  ist  = y-c;
+  q  = 1 - d;
+
+  e = 1;
+  
+  gp_obs = m/dA;
+  gy_obs = dA;
+end;
+
+steady;
+
+check;
+
+estimated_params;
+alp, beta_pdf, 0.356, 0.02;
+bet, beta_pdf, 0.993, 0.002;
+gam, normal_pdf, 0.0085, 0.003;
+mst, normal_pdf, 1.0002, 0.007;
+rho, beta_pdf, 0.129, 0.223;
+psi, beta_pdf, 0.65, 0.05;
+del, beta_pdf, 0.01, 0.005;
+stderr e_a, inv_gamma_pdf, 0.035449, inf;
+stderr e_m, inv_gamma_pdf, 0.008862, inf;
+end;
+
+varobs gp_obs gy_obs;
+
+estimation(order=1,datafile='../fs2000/fsdat_simul', nobs=192, loglinear, mh_replic=2000, mh_nblocks=2, mh_jscale=0.8);
+
+posterior_function_results=execute_prior_posterior_function('posterior_function_demo',M_,options_,oo_,estim_params_,bayestopt_,dataset_,dataset_info,'posterior')
+
+% read out the contents of the cell and put them into ndraws by ncolumns
+posterior_params=cell2mat(posterior_function_results(:,1));
+posterior_steady_states=cell2mat(posterior_function_results(:,2));
+
+prior_function_results=execute_prior_posterior_function('posterior_function_demo',M_,options_,oo_,estim_params_,bayestopt_,dataset_,dataset_info,'prior')
+
+% read out the contents of the cell and put them into ndraws by ncolumns
+prior_params=cell2mat(posterior_function_results(:,1));
+prior_steady_states=cell2mat(posterior_function_results(:,2));

--- a/tests/prior_posterior_function/posterior_function_demo.m
+++ b/tests/prior_posterior_function/posterior_function_demo.m
@@ -1,0 +1,56 @@
+function output_cell =posterior_function_demo(xparam1,M_,options_,oo_,estim_params_,bayestopt_,dataset_,dataset_info)
+% output_cell =posterior_function_demo(xparam1,M_,options_,oo_,estim_params_,bayestopt_,dataset_,dataset_info);
+% This is an example file computing statistics on the prior/posterior draws. The
+% function allows read-only access to all Dynare structures. However, those
+% structures are local to this function.  Changing them will not affect
+% other Dynare functions and you cannot use them to pass results to other
+% Dynare functions.
+% The function takes one and only one output argument: an 1 by n cell.
+% Using functions like cell2mat, the contents of the cell can be easily
+% transformed back to matrices. See the fs2000_posterior_function.mod for
+% an example
+
+% INPUTS
+%   xparam1                      Current parameter draw
+%   M_           [structure]     Matlab's structure describing the Model (initialized by dynare, see @ref{M_}).
+%   options_     [structure]     Matlab's structure describing the options (initialized by dynare, see @ref{options_}).
+%   oo_          [structure]     Matlab's structure gathering the results (initialized by dynare, see @ref{oo_}).
+%   estim_params_[structure]     Matlab's structure describing the estimated_parameters (initialized by dynare, see @ref{estim_params_}).
+%   bayestopt_   [structure]     Matlab's structure describing the parameter options (initialized by dynare, see @ref{bayestopt_}).
+%   dataset_     [structure]     Matlab's structure storing the dataset
+%   dataset_info [structure]     Matlab's structure storing the information about the dataset
+
+% Output
+%   output_cell  [1 by n cell]   1 by n Matlab cell allowing to store any
+%                                desired computation or result (strings, matrices, structures, etc.)
+
+% Copyright (C) 2015 Dynare Team
+%
+% This file is part of Dynare.
+%
+% Dynare is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% Dynare is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with Dynare.  If not, see <http://www.gnu.org/licenses/>.
+
+
+%% store the mean of the parameter draw
+output_cell{1,1}=mean(xparam1);
+
+%% compute the steady state for the parameter draw and store it
+% set the parameters draws to the model structure
+M_ = set_all_parameters(xparam1,estim_params_,M_);
+% compute the steady state for the parameter draw written to M_
+[ys,params,info] = evaluate_steady_state(oo_.steady_state,M_,options_,oo_,0);
+
+%set second part of output cell
+output_cell{1,2}=ys';
+end


### PR DESCRIPTION
Implements the functionality for #332 following the discussion in #417 
@houtanb Still missing is the preprocessor implementation that translates a call like
```posterior_function_results=execute_prior_posterior_function('posterior_function_demo','posterior') ```
into
 
```posterior_function_results=execute_prior_posterior_function('posterior_function_demo',M_,options_,oo_,estim_params_,bayestopt_,dataset_,dataset_info,'posterior') ```

The only option should be ```prior_posterior_sampling_draws```.
