### PR TITLE
Fix crash in error message display of perfect_foresight_setup.m when mor...

### DIFF
--- a/matlab/perfect-foresight-models/perfect_foresight_setup.m
+++ b/matlab/perfect-foresight-models/perfect_foresight_setup.m
@@ -34,8 +34,16 @@ global M_ options_ oo_
 test_for_deep_parameters_calibration(M_);
 
 if size(M_.lead_lag_incidence,2)-nnz(M_.lead_lag_incidence(M_.maximum_endo_lag+1,:)) > 0
-    mess = ['PERFECT_FORESIGHT_SETUP: error in model specification : variable ' M_.endo_names(find(M_.lead_lag_incidence(M_.maximum_lag+1,:)==0),:)];
-    mess = [mess ' doesn''t appear as current variable.'];
+    mess = ['PERFECT_FORESIGHT_SETUP: error in model specification : the variable(s) '];
+        var_list=M_.endo_names(find(M_.lead_lag_incidence(M_.maximum_lag+1,:)==0),:);
+        for i=1:size(var_list,1)
+            if i<size(var_list,1)
+                mess = [mess, deblank(var_list(i,:)) ', '];
+            else
+                mess = [mess, deblank(var_list(i,:)) ];
+            end
+        end
+    mess = [mess ' don''t appear as current period variables.'];
     error(mess)
 end
 


### PR DESCRIPTION
...e than one variable is not present in current period

Concatenation otherwise crashes due to non-conformable matrices