### PR TITLE
Rename static_and_dynamic_models_differ field to static_dynamic_models_d...

### DIFF
--- a/matlab/evaluate_steady_state.m
+++ b/matlab/evaluate_steady_state.m
@@ -247,7 +247,7 @@ function [ys,params,info] = evaluate_steady_state(ys_init,M,options,oo,steadysta
     end
 
     % If some equations are tagged [static] or [dynamic], verify consistency
-    if M.static_and_dynamic_models_differ
+    if M.static_dynamic_models_differ
         % Evaluate residual of *dynamic* model using the steady state
         % computed on the *static* one
         z = repmat(ys,1,M.maximum_lead + M.maximum_lag + 1);

--- a/preprocessor/DynamicModel.cc
+++ b/preprocessor/DynamicModel.cc
@@ -2399,7 +2399,7 @@ DynamicModel::writeOutput(ostream &output, const string &basename, bool block_de
 
   /* Say if static and dynamic models differ (because of [static] and [dynamic]
      equation tags) */
-  output << "M_.static_and_dynamic_models_differ = "
+  output << "M_.static_dynamic_models_differ = "
          << (static_only_equations.size() > 0 ? "1" : "0")
          << ";" << endl;
 


### PR DESCRIPTION
...iffer to fix unit tests under Linux (initval_file/ramst_initval_file.mod)

Apparently, field lengths in Octave under Linux are restricted to 31 characters. Any characters after that seem to be cut away.
