### PR TITLE
Add check for presence of NaN in JJ to identification_analysis.m

### DIFF
--- a/matlab/identification_analysis.m
+++ b/matlab/identification_analysis.m
@@ -85,6 +85,9 @@ if info(1)==0,
     derivatives_info.DYss=dYss;
     if init,
         indJJ = (find(max(abs(JJ'),[],1)>1.e-8));
+        if isempty(indJJ) && any(any(isnan(JJ)))
+            error('There are NaN in the JJ matrix. Please check whether your model has units roots and you forgot to set lik_init~=1.' )
+        end
         while length(indJJ)<nparam && nlags<10,
             disp('The number of moments with non-zero derivative is smaller than the number of parameters')
             disp(['Try increasing ar = ', int2str(nlags+1)])           


### PR DESCRIPTION
Usually happens when model has a unit root and unconditional second moments are NaN