### PR TITLE
Filter out case where estimated_params block is present but smoother …

### DIFF
--- a/matlab/DsgeSmoother.m
+++ b/matlab/DsgeSmoother.m
@@ -64,7 +64,9 @@ decomp        = [];
 vobs            = length(options_.varobs);
 smpl          = size(Y,2);
 
-M_ = set_all_parameters(xparam1,estim_params_,M_);
+if ~isempty(xparam1) %not calibrated model
+    M_ = set_all_parameters(xparam1,estim_params_,M_);
+end
 
 %------------------------------------------------------------------------------
 % 2. call model setup & reduction program


### PR DESCRIPTION
…on calibration is requested

In this case, xparam1 will be empty while estim_params_ does not have conformable dimensions.