### PR TITLE
Add unit tests for dealing with multiple leads and lags

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -192,7 +192,13 @@ MODFILES = \
 	deterministic_simulations/rbc_det_exo_lag_2a.mod \
 	deterministic_simulations/rbc_det_exo_lag_2b.mod \
 	deterministic_simulations/rbc_det_exo_lag_2c.mod \
-	deterministic_simulations/sim_several_leads_lags.mod \
+	deterministic_simulations/multiple_lead_lags/sim_base.mod \
+	deterministic_simulations/multiple_lead_lags/sim_exo_lead_lag_aux_vars.mod \
+	deterministic_simulations/multiple_lead_lags/sim_exo_lead_lag.mod \
+	deterministic_simulations/multiple_lead_lags/sim_endo_lead_lag_aux_vars.mod \
+	deterministic_simulations/multiple_lead_lags/sim_endo_lead_lag.mod \
+	deterministic_simulations/multiple_lead_lags/sim_lead_lag_aux_vars.mod \
+	deterministic_simulations/multiple_lead_lags/sim_lead_lag.mod \
 	deterministic_simulations/lola_solve_one_boundary.mod \
 	deterministic_simulations/linear_approximation/sw.mod \
 	walsh.mod \
@@ -323,6 +329,23 @@ initval_file/ramst_initval_file.o.trs: initval_file/ramst_initval_file_data.o.tl
 identification/rbc_ident/rbc_ident_varexo_only.m.trs: identification/rbc_ident/rbc_ident_std_as_structural_par.m.trs
 identification/rbc_ident/rbc_ident_varexo_only.o.trs: identification/rbc_ident/rbc_ident_std_as_structural_par.o.trs
 
+deterministic_simulations/multiple_lead_lags/sim_exo_lead_lag_aux_vars.m.trs: deterministic_simulations/multiple_lead_lags/sim_base.m.trs
+deterministic_simulations/multiple_lead_lags/sim_exo_lead_lag_aux_vars.o.trs: deterministic_simulations/multiple_lead_lags/sim_base.o.trs
+
+deterministic_simulations/multiple_lead_lags/sim_exo_lead_lag.m.trs: deterministic_simulations/multiple_lead_lags/sim_base.m.trs deterministic_simulations/multiple_lead_lags/sim_exo_lead_lag_aux_vars.m.trs
+deterministic_simulations/multiple_lead_lags/sim_exo_lead_lag.o.trs: deterministic_simulations/multiple_lead_lags/sim_base.o.trs deterministic_simulations/multiple_lead_lags/sim_exo_lead_lag_aux_vars.o.trs
+
+deterministic_simulations/multiple_lead_lags/sim_endo_lead_lag_aux_vars.m.trs: deterministic_simulations/multiple_lead_lags/sim_base.m.trs
+deterministic_simulations/multiple_lead_lags/sim_endo_lead_lag_aux_vars.o.trs: deterministic_simulations/multiple_lead_lags/sim_base.o.trs
+
+deterministic_simulations/multiple_lead_lags/sim_endo_lead_lag.m.trs: deterministic_simulations/multiple_lead_lags/sim_base.m.trs deterministic_simulations/multiple_lead_lags/sim_endo_lead_lag_aux_vars.m.trs
+deterministic_simulations/multiple_lead_lags/sim_endo_lead_lag.o.trs: deterministic_simulations/multiple_lead_lags/sim_base.o.trs deterministic_simulations/multiple_lead_lags/sim_endo_lead_lag_aux_vars.o.trs
+
+deterministic_simulations/multiple_lead_lags/sim_lead_lag_aux_vars.m.trs: deterministic_simulations/multiple_lead_lags/sim_base.m.trs
+deterministic_simulations/multiple_lead_lags/sim_lead_lag_aux_vars.o.trs: deterministic_simulations/multiple_lead_lags/sim_base.o.trs
+
+deterministic_simulations/multiple_lead_lags/sim_lead_lag.m.trs: deterministic_simulations/multiple_lead_lags/sim_base.m.trs deterministic_simulations/multiple_lead_lags/sim_lead_lag_aux_vars.m.trs
+deterministic_simulations/multiple_lead_lags/sim_lead_lag.o.trs: deterministic_simulations/multiple_lead_lags/sim_base.o.trs deterministic_simulations/multiple_lead_lags/sim_lead_lag_aux_vars.o.trs
 
 # Matlab TRS Files
 M_TRS_FILES = $(patsubst %.mod, %.m.trs, $(MODFILES))

--- a/tests/deterministic_simulations/multiple_lead_lags/sim_base.mod
+++ b/tests/deterministic_simulations/multiple_lead_lags/sim_base.mod
@@ -1,5 +1,7 @@
-var c k z_forward z_backward;
-varexo x z_shock;
+// Base simulation file adapted from ramst.mod
+
+var c k;
+varexo x;
 
 parameters alph gam delt bet aa;
 alph=0.5;
@@ -11,19 +13,12 @@ aa=0.5;
 model;
 c + k - aa*x*k(-1)^alph - (1-delt)*k(-1); // Resource constraint
 c^(-gam) - (1+bet)^(-1)*(aa*alph*x(+1)*k^(alph-1) + 1 - delt)*c(+1)^(-gam); // Euler equation
-z_backward=0.1*1+0.3*z_backward(-1)+0.3*z_backward(-2)+0.3*z_backward(-3)+(x(-4)-1);
-z_forward=0.1*1+0.45*z_forward(+1)+0.45*z_forward(+2)+(x(+4)-1);
 end;
 
 initval;
 c = 1.2;
 k = 12;
 x = 1;
-end;
-
-histval;
-x(-1)=1.30;
-x(-2)=1.30;
 end;
 
 shocks;

--- a/tests/deterministic_simulations/multiple_lead_lags/sim_endo_lead_lag.mod
+++ b/tests/deterministic_simulations/multiple_lead_lags/sim_endo_lead_lag.mod
@@ -1,0 +1,57 @@
+// Same model as sim_endo_lead_lag_aux_vars.mod, but no auxiliary variables to deal with leads and lags
+
+var c k z_backward z_forward;
+varexo x;
+
+parameters alph gam delt bet aa;
+alph=0.5;
+gam=0.5;
+delt=0.02;
+bet=0.05;
+aa=0.5;
+
+model;
+c + k - aa*x*k(-1)^alph - (1-delt)*k(-1); // Resource constraint
+c^(-gam) - (1+bet)^(-1)*(aa*alph*x(+1)*k^(alph-1) + 1 - delt)*c(+1)^(-gam); // Euler equation
+z_backward=0.4*0.5+0.2*z_backward(-1)+0.2*z_backward(-2)+0.2*z_backward(-3) + (x(-1)-1);
+z_forward=0.1*1+0.45*z_forward(+1)+0.45*z_forward(+2)+(x(+1)-1);
+end;
+
+initval;
+c = 1.2;
+k = 12;
+x = 1; %set x(0)
+z_backward=0.5;
+end;
+
+histval;
+z_backward(-1)=0.4;
+z_backward(-2)=0.9;
+end;
+
+shocks;
+var x; %sets x(+2)
+periods 2;
+values 0.9;
+end;
+
+simul(periods=200,maxit=100);
+base_results=load('sim_base_results.mat');
+if max(abs(base_results.oo_.endo_simul(strmatch('c',base_results.M_.endo_names,'exact'),1+base_results.M_.maximum_endo_lag:end-base_results.M_.maximum_endo_lead) -...
+    oo_.endo_simul(strmatch('c',M_.endo_names,'exact'),1+M_.maximum_endo_lag:end-M_.maximum_endo_lead)))>1e-8 || ...
+    max(abs(base_results.oo_.endo_simul(strmatch('k',base_results.M_.endo_names,'exact'),1+base_results.M_.maximum_endo_lag:end-base_results.M_.maximum_endo_lead) -...
+        oo_.endo_simul(strmatch('k',M_.endo_names,'exact'),1+M_.maximum_endo_lag:end-M_.maximum_endo_lead)))>1e-8
+    error('Autonomous system part is wrong')
+end
+
+if max(abs(base_results.oo_.exo_simul(1:end-base_results.M_.maximum_lead-base_results.M_.maximum_lag,strmatch('x',base_results.M_.exo_names,'exact')) -...
+    oo_.exo_simul(1+M_.maximum_lag:end-M_.maximum_lead,strmatch('x',M_.exo_names,'exact'))))>1e-8 
+    error('Translation of exogenous variables is wrong')
+end
+
+clear base_results;
+base_results_aux_vars=load('sim_endo_lead_lag_aux_vars_results.mat');
+if max(abs(base_results_aux_vars.oo_.endo_simul(strmatch('z_backward_lag_3',base_results_aux_vars.M_.endo_names,'exact'),1:end-base_results_aux_vars.M_.maximum_lead) -...
+    oo_.endo_simul(strmatch('AUX_ENDO_LAG_2_2',M_.endo_names,'exact'),1:end-M_.maximum_lag)))>1e-8 
+    error('Translation of endogenous variables is wrong')
+end

--- a/tests/deterministic_simulations/multiple_lead_lags/sim_endo_lead_lag_aux_vars.mod
+++ b/tests/deterministic_simulations/multiple_lead_lags/sim_endo_lead_lag_aux_vars.mod
@@ -1,0 +1,51 @@
+// Uses autonomous system from sim_base.mod, but adds separate system where endogenous variables have several leads and lags
+// Lags and leads on endogenous variables are substituted out by auxiliary variables
+
+var c k z_backward z_forward
+    z_backward_lag_1 z_backward_lag_2 z_backward_lag_3 z_forward_lead_1 z_forward_lead_2;
+varexo x;
+
+parameters alph gam delt bet aa;
+alph=0.5;
+gam=0.5;
+delt=0.02;
+bet=0.05;
+aa=0.5;
+
+model;
+c + k - aa*x*k(-1)^alph - (1-delt)*k(-1); // Resource constraint
+c^(-gam) - (1+bet)^(-1)*(aa*alph*x(+1)*k^(alph-1) + 1 - delt)*c(+1)^(-gam); // Euler equation
+z_backward=0.4*0.5+0.2*z_backward_lag_1+0.2*z_backward_lag_2+0.2*z_backward_lag_3 + (x(-1)-1);
+z_forward=0.1*1+0.45*z_forward_lead_1+0.45*z_forward_lead_2+(x(+1)-1);
+
+z_backward_lag_1=z_backward(-1); 
+z_backward_lag_2=z_backward_lag_1(-1); 
+z_backward_lag_3=z_backward_lag_2(-1);
+z_forward_lead_1=z_forward(+1); 
+z_forward_lead_2=z_forward_lead_1(+1); 
+end;
+
+initval;
+c = 1.2;
+k = 12;
+x = 1; %set x(0)
+z_backward=0.5;
+z_backward_lag_1=0.4;
+z_backward_lag_2=0.9;
+end;
+
+
+shocks;
+var x; %sets x(+2)
+periods 2;
+values 0.9;
+end;
+
+simul(periods=200,maxit=100);
+base_results=load('sim_base_results.mat');
+if max(abs(base_results.oo_.endo_simul(strmatch('c',base_results.M_.endo_names,'exact'),1+base_results.M_.maximum_endo_lag:end-base_results.M_.maximum_endo_lead) -...
+    oo_.endo_simul(strmatch('c',M_.endo_names,'exact'),1+M_.maximum_endo_lag:end-M_.maximum_endo_lead)))>1e-8 || ...
+    max(abs(base_results.oo_.endo_simul(strmatch('k',base_results.M_.endo_names,'exact'),1+base_results.M_.maximum_endo_lag:end-base_results.M_.maximum_endo_lead) -...
+        oo_.endo_simul(strmatch('k',M_.endo_names,'exact'),1+M_.maximum_endo_lag:end-M_.maximum_endo_lead)))>1e-8
+    error('Autonomous system part is wrong')
+end

--- a/tests/deterministic_simulations/multiple_lead_lags/sim_exo_lead_lag.mod
+++ b/tests/deterministic_simulations/multiple_lead_lags/sim_exo_lead_lag.mod
@@ -1,0 +1,52 @@
+// Same model as sim_exo_lead_lag_aux_vars.mod, but no auxiliary variables to deal with leads and lags
+
+var c k z_forward z_backward;
+varexo x z_shock;
+
+parameters alph gam delt bet aa;
+alph=0.5;
+gam=0.5;
+delt=0.02;
+bet=0.05;
+aa=0.5;
+
+model;
+c + k - aa*x*k(-1)^alph - (1-delt)*k(-1); // Resource constraint
+c^(-gam) - (1+bet)^(-1)*(aa*alph*x(+1)*k^(alph-1) + 1 - delt)*c(+1)^(-gam); // Euler equation
+z_backward=0.1*1+0.9*z_backward(-1)+(x(-4)-1);
+z_forward=0.2*1+0.8*z_forward(+1)+(x(+4)-1);
+end;
+
+initval;
+c = 1.2;
+k = 12;
+x = 1; %set x(0)
+end;
+
+histval;
+x(-1)=1.30; %set x(-1)
+x(-2)=1.30; %set x(-2)
+end;
+
+shocks;
+var x; %set x(2)
+periods 2;
+values 0.9;
+end;
+
+simul(periods=200,maxit=100);
+base_results=load('sim_base_results.mat');
+if max(abs(base_results.oo_.endo_simul(strmatch('c',base_results.M_.endo_names,'exact'),1+base_results.M_.maximum_endo_lag:end-base_results.M_.maximum_endo_lead) -...
+    oo_.endo_simul(strmatch('c',M_.endo_names,'exact'),1+M_.maximum_lag:end-M_.maximum_lead)))>1e-8 || ...
+    max(abs(base_results.oo_.endo_simul(strmatch('k',base_results.M_.endo_names,'exact'),1+base_results.M_.maximum_endo_lag:end-base_results.M_.maximum_endo_lead) -...
+        oo_.endo_simul(strmatch('k',M_.endo_names,'exact'),1+M_.maximum_lag:end-M_.maximum_lead)))>1e-8
+    error('Autonomous system part is wrong')
+end
+
+clear base_results
+base_results_aux_vars=load('sim_exo_lead_lag_aux_vars_results.mat');
+
+if max(abs(base_results_aux_vars.oo_.endo_simul(strmatch('x_lag_4',base_results_aux_vars.M_.endo_names,'exact'),1:end-base_results_aux_vars.M_.maximum_lead)' -...
+    oo_.exo_simul(1:end-M_.maximum_lead-M_.maximum_lag,strmatch('x',M_.exo_names,'exact'))))>1e-8 
+    error('Translation of aux vars is wrong')
+end

--- a/tests/deterministic_simulations/multiple_lead_lags/sim_exo_lead_lag_aux_vars.mod
+++ b/tests/deterministic_simulations/multiple_lead_lags/sim_exo_lead_lag_aux_vars.mod
@@ -1,0 +1,52 @@
+// Uses autonomous system from sim_base.mod, but adds separate system where exogenous variables have several leads and lags
+// Lags and leads on exogenous variables are substituted out by auxiliary variables
+
+var c k z_backward z_forward x_lag_1 x_lag_2 x_lag_3 x_lag_4 x_lead_1 x_lead_2 x_lead_3 x_lead_4;
+varexo x;
+
+parameters alph gam delt bet aa;
+alph=0.5;
+gam=0.5;
+delt=0.02;
+bet=0.05;
+aa=0.5;
+
+model;
+c + k - aa*x*k(-1)^alph - (1-delt)*k(-1); // Resource constraint
+c^(-gam) - (1+bet)^(-1)*(aa*alph*x(+1)*k^(alph-1) + 1 - delt)*c(+1)^(-gam); // Euler equation
+z_backward=0.1*1+0.9*z_backward(-1)+(x_lag_4-1);
+z_forward=0.2*1+0.8*z_forward(+1)+(x_lead_4-1);
+
+x_lag_1=x(-1);
+x_lag_2=x_lag_1(-1);
+x_lag_3=x_lag_2(-1);
+x_lag_4=x_lag_3(-1);
+x_lead_1=x(+1);
+x_lead_2=x_lead_1(+1);
+x_lead_3=x_lead_2(+1);
+x_lead_4=x_lead_3(+1);
+end;
+
+initval;
+c = 1.2;
+k = 12;
+x = 1; %set x(0)
+x_lag_1 = 1.3; %sets x(-1)
+x_lag_2 = 1.3; %sets x(-2)
+end;
+
+shocks;
+var x; %sets x(+2)
+periods 2;
+values 0.9;
+end;
+
+simul(periods=200,maxit=100);
+base_results=load('sim_base_results.mat');
+if max(abs(base_results.oo_.endo_simul(strmatch('c',base_results.M_.endo_names,'exact'),1+base_results.M_.maximum_endo_lag:end-base_results.M_.maximum_endo_lead) -...
+    oo_.endo_simul(strmatch('c',M_.endo_names,'exact'),1+M_.maximum_endo_lag:end-M_.maximum_endo_lead)))>1e-8 || ...
+    max(abs(base_results.oo_.endo_simul(strmatch('k',base_results.M_.endo_names,'exact'),1+base_results.M_.maximum_endo_lag:end-base_results.M_.maximum_endo_lead) -...
+        oo_.endo_simul(strmatch('k',M_.endo_names,'exact'),1+M_.maximum_endo_lag:end-M_.maximum_endo_lead)))>1e-8
+    error('Autonomous system part is wrong')
+end
+

--- a/tests/deterministic_simulations/multiple_lead_lags/sim_lead_lag.mod
+++ b/tests/deterministic_simulations/multiple_lead_lags/sim_lead_lag.mod
@@ -1,0 +1,56 @@
+// Same model as sim_lead_lag_aux_vars.mod, but no auxiliary variables to deal with leads and lags
+
+var c k z_forward z_backward;
+varexo x z_shock;
+
+parameters alph gam delt bet aa;
+alph=0.5;
+gam=0.5;
+delt=0.02;
+bet=0.05;
+aa=0.5;
+
+model;
+c + k - aa*x*k(-1)^alph - (1-delt)*k(-1); // Resource constraint
+c^(-gam) - (1+bet)^(-1)*(aa*alph*x(+1)*k^(alph-1) + 1 - delt)*c(+1)^(-gam); // Euler equation
+z_backward=0.1*1+0.3*z_backward(-1)+0.3*z_backward(-2)+0.3*z_backward(-3)+(x(-4)-1);
+z_forward=0.1*1+0.45*z_forward(+1)+0.45*z_forward(+2)+(x(+4)-1);
+end;
+
+initval;
+c = 1.2;
+k = 12;
+x = 1; %set x(0)
+z_backward=0.5; %set z_backward(0)
+end;
+
+histval;
+x(-1)=1.30; %set x(-1)
+x(-2)=1.30; %set x(-2)
+z_backward(-1)=0.4; %set z_backward(-1)
+z_backward(-2)=0.9; %set z_backward(-2)
+end;
+
+
+shocks;
+var x; %set x(2)
+periods 2;
+values 0.9;
+end;
+
+simul(periods=200,maxit=100);
+base_results=load('sim_base_results.mat');
+if max(abs(base_results.oo_.endo_simul(strmatch('c',base_results.M_.endo_names,'exact'),1+base_results.M_.maximum_endo_lag:end-base_results.M_.maximum_endo_lead) -...
+    oo_.endo_simul(strmatch('c',M_.endo_names,'exact'),1+M_.maximum_lag:end-M_.maximum_lead)))>1e-8 || ...
+    max(abs(base_results.oo_.endo_simul(strmatch('k',base_results.M_.endo_names,'exact'),1+base_results.M_.maximum_endo_lag:end-base_results.M_.maximum_endo_lead) -...
+        oo_.endo_simul(strmatch('k',M_.endo_names,'exact'),1+M_.maximum_lag:end-M_.maximum_lead)))>1e-8
+    error('Autonomous system part is wrong')
+end
+
+clear base_results
+base_results_aux_vars=load('sim_lead_lag_aux_vars_results.mat');
+
+if max(abs(base_results_aux_vars.oo_.endo_simul(strmatch('x_lag_4',base_results_aux_vars.M_.endo_names,'exact'),1:end-base_results_aux_vars.M_.maximum_lead)' -...
+    oo_.exo_simul(1:end-M_.maximum_lead-M_.maximum_lag,strmatch('x',M_.exo_names,'exact'))))>1e-8 
+    error('Translation of aux vars is wrong')
+end

--- a/tests/deterministic_simulations/multiple_lead_lags/sim_lead_lag_aux_vars.mod
+++ b/tests/deterministic_simulations/multiple_lead_lags/sim_lead_lag_aux_vars.mod
@@ -1,0 +1,62 @@
+// Uses autonomous system from sim_base.mod, but adds separate system where exogenous and endogenous variables have several leads and lags
+// Lags and leads on variables are substituted out by auxiliary variables
+
+var c k z_backward z_forward x_lag_1 x_lag_2 x_lag_3 x_lag_4 x_lead_1 x_lead_2 x_lead_3 x_lead_4
+    z_backward_lag_1 z_backward_lag_2 z_backward_lag_3 z_forward_lead_1 z_forward_lead_2;
+varexo x;
+
+parameters alph gam delt bet aa;
+alph=0.5;
+gam=0.5;
+delt=0.02;
+bet=0.05;
+aa=0.5;
+
+model;
+c + k - aa*x*k(-1)^alph - (1-delt)*k(-1); // Resource constraint
+c^(-gam) - (1+bet)^(-1)*(aa*alph*x(+1)*k^(alph-1) + 1 - delt)*c(+1)^(-gam); // Euler equation
+z_backward=0.4*0.5+0.2*z_backward_lag_1+0.2*z_backward_lag_2+0.2*z_backward_lag_3 + (x_lag_4-1);
+z_forward=0.1*1+0.45*z_forward_lead_1+0.45*z_forward_lead_2+(x_lead_4-1);
+
+z_backward_lag_1=z_backward(-1); 
+z_backward_lag_2=z_backward_lag_1(-1); 
+z_backward_lag_3=z_backward_lag_2(-1);
+z_forward_lead_1=z_forward(+1); 
+z_forward_lead_2=z_forward_lead_1(+1); 
+
+x_lag_1=x(-1);
+x_lag_2=x_lag_1(-1);
+x_lag_3=x_lag_2(-1);
+x_lag_4=x_lag_3(-1);
+x_lead_1=x(+1);
+x_lead_2=x_lead_1(+1);
+x_lead_3=x_lead_2(+1);
+x_lead_4=x_lead_3(+1);
+end;
+
+initval;
+c = 1.2;
+k = 12;
+x = 1; %set x(0)
+x_lag_1 = 1.3; %sets x(-1)
+x_lag_2 = 1.3; %sets x(-2)
+z_backward=0.5;
+z_backward_lag_1=0.4;
+z_backward_lag_2=0.9;
+end;
+
+shocks;
+var x; %sets x(+2)
+periods 2;
+values 0.9;
+end;
+
+simul(periods=200,maxit=100);
+base_results=load('sim_base_results.mat');
+if max(abs(base_results.oo_.endo_simul(strmatch('c',base_results.M_.endo_names,'exact'),1+base_results.M_.maximum_endo_lag:end-base_results.M_.maximum_endo_lead) -...
+    oo_.endo_simul(strmatch('c',M_.endo_names,'exact'),1+M_.maximum_endo_lag:end-M_.maximum_endo_lead)))>1e-8 || ...
+    max(abs(base_results.oo_.endo_simul(strmatch('k',base_results.M_.endo_names,'exact'),1+base_results.M_.maximum_endo_lag:end-base_results.M_.maximum_endo_lead) -...
+        oo_.endo_simul(strmatch('k',M_.endo_names,'exact'),1+M_.maximum_endo_lag:end-M_.maximum_endo_lead)))>1e-8
+    error('Autonomous system part is wrong')
+end
+


### PR DESCRIPTION
- Adds systematic tests for dealing with several leads and lags in perfect foresight simulations
- Allows testing the progress in #617 