### PR TITLE
Add check whether bayestopt_ is empty

### DIFF
--- a/matlab/dynare_estimation_init.m
+++ b/matlab/dynare_estimation_init.m
@@ -148,7 +148,7 @@ if ~isempty(estim_params_)
     [xparam1,estim_params_,bayestopt_,lb,ub,M_] = set_prior(estim_params_,M_,options_);
 end
 
-if any(bayestopt_.pshape==0) && any(bayestopt_.pshape~=0)
+if ~isempty(bayestopt_) && any(bayestopt_.pshape==0) && any(bayestopt_.pshape~=0)
     error('Estimation must be either fully ML or fully Bayesian. Maybe you forgot to specify a prior distribution.')
 end
 % Check if a _prior_restrictions.m file exists


### PR DESCRIPTION
Otherwise crashes for calibrated smoother occur. Solves unit tests crashes