### PR TITLE
Add missing return statement to evaluate_steady_state_file.m

### DIFF
--- a/matlab/evaluate_steady_state_file.m
+++ b/matlab/evaluate_steady_state_file.m
@@ -57,6 +57,7 @@ function [ys,params,info] = evaluate_steady_state_file(ys_init,exo_ss,M,options)
     if check
         info(1) = 19;
         info(2) = NaN;
+        return
     end
     
     if M.param_nbr > 0


### PR DESCRIPTION
Otherwise, the code will subsequently crash if the steady state file does not return a conformably sized vector, although an error code was returned