### PR TITLE
Various fixes for discretionary_policy

### DIFF
--- a/matlab/discretionary_policy.m
+++ b/matlab/discretionary_policy.m
@@ -35,6 +35,6 @@ if options_.noprint == 0
 end
 
 
-%oo_ = evaluate_planner_objective(oo_.dr,M_,oo_,options_);
+oo_.planner_objective_value = evaluate_planner_objective(M_,options_,oo_);
 
 options_ = oldoptions;

--- a/matlab/discretionary_policy_1.m
+++ b/matlab/discretionary_policy_1.m
@@ -78,7 +78,8 @@ it_ = MaxLag + 1 ;
 if exo_nbr == 0
     oo_.exo_steady_state = [] ;
 end
-[junk,jacobia_] = feval([M_.fname '_dynamic'],z, [oo_.exo_simul ...
+
+[junk,jacobia_] = feval([M_.fname '_dynamic'],z, [zeros(size(oo_.exo_simul)) ...
                     oo_.exo_det_simul], M_.params, zeros(endo_nbr,1), it_);
 if any(junk~=0)
     error(['discretionary_policy: the model must be written in deviation ' ...

--- a/matlab/discretionary_policy_1.m
+++ b/matlab/discretionary_policy_1.m
@@ -88,7 +88,13 @@ end
 eq_nbr= size(jacobia_,1);
 instr_nbr=endo_nbr-eq_nbr;
 
-  
+if instr_nbr==0
+    error('discretionary_policy:: There are no available instruments, because the model has as many equations as variables.') 
+end
+if size(Instruments,1)~= instr_nbr
+   error('discretionary_policy:: There are more declared instruments than omitted equations.') 
+end 
+
 instr_id=nan(instr_nbr,1);
 for j=1:instr_nbr
 	vj=deblank(Instruments(j,:));

--- a/matlab/evaluate_planner_objective.m
+++ b/matlab/evaluate_planner_objective.m
@@ -92,7 +92,6 @@ if ~isempty(M.endo_histval)
     end
 end
 yhat1 = yhat1(dr.order_var(nstatic+(1:nspred)),1)-dr.ys(dr.order_var(nstatic+(1:nspred)));
-yhat2 = yhat2(dr.order_var(nstatic+(1:nspred)),1)-dr.ys(dr.order_var(nstatic+(1:nspred)));
 u = oo.exo_simul(1,:)';
 
 [Wyyyhatyhat1, err] = A_times_B_kronecker_C(Wyy,yhat1,yhat1,options.threads.kronecker.A_times_B_kronecker_C);
@@ -104,6 +103,7 @@ mexErrCheck('A_times_B_kronecker_C', err);
 planner_objective_value(1) = Wbar+Wy*yhat1+Wu*u+Wyuyhatu1 ...
     + 0.5*(Wyyyhatyhat1 + Wuuuu+Wss);
 if options.ramsey_policy
+    yhat2 = yhat2(dr.order_var(nstatic+(1:nspred)),1)-dr.ys(dr.order_var(nstatic+(1:nspred)));
     [Wyyyhatyhat2, err] = A_times_B_kronecker_C(Wyy,yhat2,yhat2,options.threads.kronecker.A_times_B_kronecker_C);
     mexErrCheck('A_times_B_kronecker_C', err);
     [Wyuyhatu2, err] = A_times_B_kronecker_C(Wyu,yhat2,u,options.threads.kronecker.A_times_B_kronecker_C);
@@ -115,9 +115,13 @@ end
 if ~options.noprint
     skipline()
     disp('Approximated value of planner objective function')
-    disp(['    - with initial Lagrange multipliers set to 0: ' ...
+    if options.ramsey_policy
+        disp(['    - with initial Lagrange multipliers set to 0: ' ...
           num2str(planner_objective_value(2)) ])
-    disp(['    - with initial Lagrange multipliers set to steady state: ' ...
-          num2str(planner_objective_value(1)) ])
+        disp(['    - with initial Lagrange multipliers set to steady state: ' ...
+              num2str(planner_objective_value(1)) ])
+    elseif options.discretionary_policy
+        fprintf('with discretionary policy: %10.8f',planner_objective_value(1))
+    end
     skipline()
 end

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -43,6 +43,7 @@ MODFILES = \
 	optimal_policy/Ramsey/ramsey_ex_aux.mod \
 	optimal_policy/RamseyConstraints/test1.mod \
 	discretionary_policy/dennis_1.mod \
+	discretionary_policy/Gali_discretion.mod \
 	initval_file/ramst_initval_file.mod \
 	ramst_normcdf_and_friends.mod \
 	ramst_vec.mod \

--- a/tests/discretionary_policy/Gali_discretion.mod
+++ b/tests/discretionary_policy/Gali_discretion.mod
@@ -1,0 +1,149 @@
+/*
+ * This file implements the baseline New Keynesian model of Jordi Galí (2008): Monetary Policy, Inflation,
+ * and the Business Cycle, Princeton University Press, Chapter 5
+ *
+ * This implementation was written by Johannes Pfeifer. 
+ *
+ * Please note that the following copyright notice only applies to this Dynare 
+ * implementation of the model.
+ */
+
+/*
+ * Copyright (C) 2013-15 Johannes Pfeifer
+ *
+ * This is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * It is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * For a copy of the GNU General Public License,
+ * see <http://www.gnu.org/licenses/>.
+ */
+
+
+var pi
+    y_gap 
+    r_e 
+    y_e
+    r_nat 
+    i 
+    u 
+    a 
+    p
+    ;     
+
+varexo eps_a 
+       eps_u;
+
+parameters alppha 
+    betta 
+    rho_a
+    rho_u 
+    siggma
+    phi 
+    phi_y 
+    eta 
+    epsilon 
+    theta 
+    ;
+%----------------------------------------------------------------
+% Parametrization, p. 52
+%----------------------------------------------------------------
+siggma = 1;
+phi=1;
+phi_y  = .5/4;
+theta=2/3;
+rho_u = 0;
+rho_a  = 0.9;
+betta = 0.99;
+eta  =4;
+alppha=1/3;
+epsilon=6;
+
+
+
+%----------------------------------------------------------------
+% First Order Conditions
+%----------------------------------------------------------------
+
+model(linear); 
+//Composite parameters
+#Omega=(1-alppha)/(1-alppha+alppha*epsilon);  //defined on page 47
+#psi_n_ya=(1+phi)/(siggma*(1-alppha)+phi+alppha); //defined on page 48
+#lambda=(1-theta)*(1-betta*theta)/theta*Omega; //defined on page 47
+#kappa=lambda*(siggma+(phi+alppha)/(1-alppha));  //defined on page 49
+#alpha_x=kappa/epsilon; //defined on page 96
+#phi_pi=(1-rho_u)*kappa*siggma/(alpha_x)+rho_u; //defined on page 101
+
+r_e=siggma*(y_e(+1)-y_e);
+y_e=psi_n_ya*a;
+pi=betta*pi(+1)+kappa*y_gap + u;
+y_gap=-1/siggma*(i-pi(+1)-r_e)+y_gap(+1);
+//3. Interest Rate Rule eq. (25)
+% i=r_e+phi_pi*pi;
+
+r_nat=siggma*psi_n_ya*(a(+1)-a);
+u=rho_u*u(-1)+eps_u;
+a=rho_a*a(-1)+eps_a;
+
+pi=p-p(-1);
+end;
+
+%----------------------------------------------------------------
+%  define shock variances
+%---------------------------------------------------------------
+
+
+shocks;
+var eps_u = 1;
+end;
+
+planner_objective pi^2 +(((1-theta)*(1-betta*theta)/theta*((1-alppha)/(1-alppha+alppha*epsilon)))*(siggma+(phi+alppha)/(1-alppha)))/epsilon*y_gap^2;
+
+discretionary_policy(instruments=(i),irf=20,planner_discount=betta,discretionary_tol=1e-12) y_gap pi p u;
+
+verbatim;
+%% Check correctness
+Omega=(1-alppha)/(1-alppha+alppha*epsilon);  %defined on page 47
+lambda=(1-theta)*(1-betta*theta)/theta*Omega; %defined on page 47
+kappa=lambda*(siggma+(phi+alppha)/(1-alppha));  %defined on page 49
+alpha_x=kappa/epsilon; %defined on page 96
+Psi=1/(kappa^2+alpha_x*(1-betta*rho_u)); %defined on page 99
+Psi_i=Psi*(kappa*siggma*(1-rho_u)+alpha_x*rho_u); %defined on page 101
+phi_pi=(1-rho_u)*kappa*siggma/(alpha_x)+rho_u; %defined on page 101
+
+%Compute theoretical solution
+var_pi_theoretical=(alpha_x*Psi)^2; %equation (6), p.99
+var_y_gap_theoretical=(-kappa*Psi)^2; %equation (7), p.99
+
+pi_pos=strmatch('pi',var_list_,'exact');
+y_gap_pos=strmatch('y_gap',var_list_,'exact');
+if abs(oo_.var(pi_pos,pi_pos)-var_pi_theoretical)>1e-10 || abs(oo_.var(y_gap_pos,y_gap_pos)-var_y_gap_theoretical)>1e-10
+   error('Variances under optimal policy are wrong')
+end
+
+%Compute theoretical objective function
+V=betta/(1-betta)*(var_pi_theoretical+alpha_x*var_y_gap_theoretical); %evaluate at steady state in first period
+
+if abs(V-oo_.planner_objective_value)>1e-10
+    error('Computed welfare deviates from theoretical welfare')
+end
+end;
+
+%% repeat exercise with initial shock of 1 to check whether planner objective is correctly specified
+initval;
+    eps_u = 1;
+end;
+
+%Compute theoretical objective function
+V=var_pi_theoretical+alpha_x*var_y_gap_theoretical+ betta/(1-betta)*(var_pi_theoretical+alpha_x*var_y_gap_theoretical); %evaluate at steady state in first period
+ 
+discretionary_policy(instruments=(i),irf=20,discretionary_tol=1e-12,planner_discount=betta) y_gap pi p u;
+if abs(V-oo_.planner_objective_value)>1e-10
+    error('Computed welfare deviates from theoretical welfare')
+end

--- a/tests/discretionary_policy/dennis_1.mod
+++ b/tests/discretionary_policy/dennis_1.mod
@@ -19,7 +19,7 @@ y = y(+1) -(omega/sigma)*(i-pi(+1))+g;
 pi =  beta*pi(+1)+kappa*y+u;
 pi_c = pi+(alpha/(1-alpha))*(q-q(-1));
 q = q(+1)-(1-alpha)*(i-pi(+1))+(1-alpha)*e;
-i = 1.5*pi;
+% i = 1.5*pi;
 end;
 
 shocks;
@@ -29,6 +29,5 @@ var e; stderr 1;
 end;
 
 planner_objective pi_c^2 + y^2;
-
-discretionary_policy(instruments=(i),irf=0,qz_criterium=0.999999);
+discretionary_policy(instruments=(i),irf=0,planner_discount=beta);
 


### PR DESCRIPTION
- Saves planner objective and closes #1041 
- Adds unit test for correctness of results
- Fixes updating of lead_lag_indicidence
- Evaluates Jacobian at steady state of model (makes it compatible with histval and initval)
- Disallows mod-files with number of instruments not matching number of missing equations

Related to #1045 

TBD: fix preprocessor error in unit test (email to Houtan from 08/30/15)