### PR TITLE
Fix exit criterion in trust_region.m

### DIFF
--- a/matlab/trust_region.m
+++ b/matlab/trust_region.m
@@ -179,8 +179,9 @@ while (niter < maxiter && ~info)
         info = 1;
     end
 end
-
-check = ~info;
+if info~=1
+    check = 1;
+end
 end
 
 


### PR DESCRIPTION
Otherwise, error code -3 (Trust region became uselessly small) was accepted as a solved steady state