### PR TITLE
Better handling of NPD MH proposal covariance

### DIFF
--- a/matlab/metropolis_hastings_initialization.m
+++ b/matlab/metropolis_hastings_initialization.m
@@ -80,7 +80,13 @@ nblck = options_.mh_nblck;
 nruns = ones(nblck,1)*options_.mh_replic;
 npar  = length(xparam1);
 MAX_nruns = ceil(options_.MaxNumberOfBytes/(npar+2)/8);
-d = chol(vv);
+[ d, notPosDef ] = chol(vv);
+if notPosDef
+    disp('WARNING: using diagonal of hessian only');
+    diagv = diag(vv);
+    diagv(diagv < 0.01) = 0.01;
+    d = diag(sqrt(diagv));
+end
 
 if ~options_.load_mh_file && ~options_.mh_recover
     % Here we start a new Metropolis-Hastings, previous draws are discarded.


### PR DESCRIPTION
Hi there, thanks a bunch for all your work on Dynare! Do you accept pull requests?

This is a tweak I always make to my local copy. Obviously an NPD Hessian is less than ideal, but with this change you can run the MCMC for a few thousand draws, which almost always makes it obvious where the problem is. The `mode_check` feature is a powerful tool, but doesn't catch everything.
