### PR TITLE
Deblank field names to prevent crashes during computation of posterio…

### DIFF
--- a/matlab/correlation_mc_analysis.m
+++ b/matlab/correlation_mc_analysis.m
@@ -43,6 +43,9 @@ else
     var2 = var1;
 end
 
+var1=deblank(var1);
+var2=deblank(var2);
+
 if isfield(oo_,[TYPE 'TheoreticalMoments'])
     temporary_structure = oo_.([TYPE, 'TheoreticalMoments']);
     if isfield(temporary_structure,'dsge')

--- a/matlab/covariance_mc_analysis.m
+++ b/matlab/covariance_mc_analysis.m
@@ -60,6 +60,9 @@ else
     var2 = var1;
 end
 
+var1=deblank(var1);
+var2=deblank(var2);
+
 if isfield(oo_,[ TYPE 'TheoreticalMoments'])
     temporary_structure = oo_.([TYPE, 'TheoreticalMoments']); 
     if isfield(temporary_structure,'dsge')

--- a/matlab/variance_decomposition_mc_analysis.m
+++ b/matlab/variance_decomposition_mc_analysis.m
@@ -61,6 +61,9 @@ if isempty(jndx)
     return
 end
 
+var=deblank(var);
+exo=deblank(exo);
+
 name = [ var '.' exo ];
 if isfield(oo_, [ TYPE 'TheoreticalMoments'])
     temporary_structure = oo_.([TYPE, 'TheoreticalMoments']);


### PR DESCRIPTION
…r moments

Necessary after switching to indirect indexing of structure fields