### PR TITLE
Julia bugfix in assert and assign params in __modfile__.jl

### DIFF
--- a/preprocessor/DynamicModel.cc
+++ b/preprocessor/DynamicModel.cc
@@ -2390,9 +2390,9 @@ DynamicModel::writeDynamicModel(ostream &DynamicOutput, bool use_dll, bool julia
                     << "                  steady_state::Vector{Float64}, it_::Int, "
                     << "residual::Vector{Float64})" << endl
                     << "#=" << endl << comments.str() << "=#" << endl
-                    << "  @assert size(y) == " << dynJacobianColsNbr << endl
-                    << "  @assert size(params) == " << symbol_table.param_nbr() << endl
-                    << "  @assert size(residual) == " << nrows << endl
+                    << "  @assert length(y) == " << dynJacobianColsNbr << endl
+                    << "  @assert length(params) == " << symbol_table.param_nbr() << endl
+                    << "  @assert length(residual) == " << nrows << endl
                     << "  #" << endl
                     << "  # Model equations" << endl
                     << "  #" << endl

--- a/preprocessor/ModFile.cc
+++ b/preprocessor/ModFile.cc
@@ -1160,6 +1160,11 @@ ModFile::writeExternalFilesJulia(const string &basename, FileOutputType output) 
     }
   steady_state_model.writeSteadyStateFile(basename, mod_file_struct.ramsey_model_present, true);
 
+  // Print statements (includes parameter values)
+    for (vector<Statement *>::const_iterator it = statements.begin();
+         it != statements.end(); it++)
+        (*it)->writeJuliaOutput(jlOutputFile, basename);
+
   jlOutputFile << "model.static = " << basename << "Static.static!" << endl
                << "model.dynamic = " << basename << "Dynamic.dynamic!" << endl
                << "model.steady_state = " << basename << "SteadyState2.steady_state!" << endl

--- a/preprocessor/NumericalInitialization.cc
+++ b/preprocessor/NumericalInitialization.cc
@@ -52,6 +52,16 @@ InitParamStatement::writeOutput(ostream &output, const string &basename, bool mi
 }
 
 void
+InitParamStatement::writeJuliaOutput(ostream &output, const string &basename)
+{
+  int id = symbol_table.getTypeSpecificID(symb_id) + 1;
+  output << "model.params[ " << id << " ] = ";
+  param_value->writeOutput(output);
+  output << endl;
+  output << symbol_table.getName(symb_id) << " = model.params[ " << id << " ]" << endl;
+}
+
+void
 InitParamStatement::writeCOutput(ostream &output, const string &basename)
 {
   int id = symbol_table.getTypeSpecificID(symb_id);

--- a/preprocessor/NumericalInitialization.hh
+++ b/preprocessor/NumericalInitialization.hh
@@ -41,6 +41,7 @@ public:
                      const SymbolTable &symbol_table_arg);
   virtual void checkPass(ModFileStructure &mod_file_struct, WarningConsolidation &warnings);
   virtual void writeOutput(ostream &output, const string &basename, bool minimal_workspace) const;
+  virtual void writeJuliaOutput(ostream &output, const string &basename);
   virtual void writeCOutput(ostream &output, const string &basename);
   //! Fill eval context with parameter value
   void fillEvalContext(eval_context_t &eval_context) const;

--- a/preprocessor/Statement.cc
+++ b/preprocessor/Statement.cc
@@ -69,6 +69,11 @@ Statement::writeCOutput(ostream &output, const string &basename)
 {
 }
 
+void Statement::writeJuliaOutput(ostream &output, const string &basename)
+{
+}
+
+
 void
 Statement::computingPass()
 {

--- a/preprocessor/Statement.hh
+++ b/preprocessor/Statement.hh
@@ -138,6 +138,7 @@ public:
   */
   virtual void writeOutput(ostream &output, const string &basename, bool minimal_workspace) const = 0;
   virtual void writeCOutput(ostream &output, const string &basename);
+  virtual void writeJuliaOutput(ostream &output, const string &basename);
 };
 
 class NativeStatement : public Statement


### PR DESCRIPTION
I found a bug in an `@assert` call in the first generated `dynamic!` method in the Julia code (`size` always returns a tuple, and we were comparing to an int. Dispatch restricts these arguments to all be vectors so `length` works here)

Also added support for filling in the `model.params` `Vector`.

I realize that the Julia support is still preliminary, but I'm happy to pitch in as I have time/need to push things forward.

