### PR TITLE
Reset seed before drawing starting points of MCMC chains

### DIFF
--- a/matlab/metropolis_hastings_initialization.m
+++ b/matlab/metropolis_hastings_initialization.m
@@ -113,6 +113,7 @@ if ~options_.load_mh_file && ~options_.mh_recover
     fprintf(fidlog,' \n');
     % Find initial values for the nblck chains...
     if nblck > 1% Case 1: multiple chains
+        set_dynare_seed('default');
         fprintf(fidlog,['  Initial values of the parameters:\n']);
         disp('Estimation::mcmc: Searching for initial values...')
         ix2 = zeros(nblck,npar);


### PR DESCRIPTION
Removes stochastics between different runs while not affecting the subsequent MCMC computations for which the seed is also reset and saved
Closes #1048