### PR TITLE
Save filter_covariance and trends in Bayesian estimation

### DIFF
--- a/doc/dynare.texi
+++ b/doc/dynare.texi
@@ -6338,7 +6338,7 @@ smoother in order of declaration of the observed variables.
 @defvr {MATLAB/Octave variable} oo_.Smoother.Trend
 Variable set by the @code{estimation} command (if used with the
 @code{smoother} option), or by the @code{calib_smoother} command.
-Contains the trend component of the observed variables used in the
+Contains the trend component of the variables used in the
 smoother.
 
 Fields are of the form:
@@ -6351,7 +6351,8 @@ Fields are of the form:
 Variable set by the @code{estimation} command (if used with the
 @code{smoother} option), or by the @code{calib_smoother} command.
 Contains the constant part of the endogenous variables used in the
-smoother.
+smoother, accounting e.g. for the data mean when using the @code{prefilter}
+option.
 
 Fields are of the form:
 @example

--- a/doc/dynare.texi
+++ b/doc/dynare.texi
@@ -5809,8 +5809,8 @@ recursions as described by @cite{Herbst, 2015}. This setting is only used with
 
 @item filter_covariance
 @anchor{filter_covariance} Saves the series of one step ahead error of
-forecast covariance matrices in @ref{oo_.Smoother.Variance}. Not available 
-with Metropolis.
+forecast covariance matrices. With Metropolis, they are saved in @ref{oo_.FilterCovariance},
+otherwise in @ref{oo_.Smoother.Variance}.
 
 @item filter_step_ahead = [@var{INTEGER1}:@var{INTEGER2}]
 See below.
@@ -6285,6 +6285,23 @@ After an estimation with Metropolis, fields are of the form:
 @example
 @code{oo_.UpdatedVariables.@var{MOMENT_NAME}.@var{VARIABLE_NAME}}
 @end example
+@end defvr
+
+@defvr {MATLAB/Octave variable} oo_.FilterCovariance
+@anchor{oo_.FilterCovariance}
+Three-dimensional array set by the @code{estimation} command if used with the
+@code{smoother} and Metropolis, if the @code{filter_covariance} option
+has been requested.
+Contains the series of one-step ahead forecast error covariance matrices
+from the Kalman smoother. The @code{M_.endo_nbr} times @code{M_.endo_nbr} times
+@code{T+1} array contains the variables in declaration order along the first 
+two dimensions. The third dimension of the array provides the
+observation for which the forecast has been made.
+Fields are of the form:
+@example
+@code{oo_.FilterCovariance.@var{MOMENT_NAME}}
+@end example
+Note that density estimation is not supported.
 @end defvr
 
 @defvr {MATLAB/Octave variable} oo_.Smoother.Variance

--- a/matlab/dyn_forecast.m
+++ b/matlab/dyn_forecast.m
@@ -107,9 +107,10 @@ switch task
         trend_coeffs = [];
         for i=1:length(var_obs)
             tmp = strmatch(var_obs{i},endo_names(i_var,:),'exact');
+            trend_var_index=strmatch(var_obs{i},M.endo_names,'exact');
             if ~isempty(tmp)
                 i_var_obs = [ i_var_obs; tmp];
-                trend_coeffs = [trend_coeffs; oo.Smoother.TrendCoeffs(i)];
+                trend_coeffs = [trend_coeffs; oo.Smoother.TrendCoeffs(trend_var_index)];
             end
         end
         if ~isempty(trend_coeffs) 

--- a/matlab/store_smoother_results.m
+++ b/matlab/store_smoother_results.m
@@ -28,7 +28,7 @@ function [oo_, yf]=store_smoother_results(M_,oo_,options_,bayestopt_,dataset_,da
 % Outputs:
 %   oo_             [structure] storing the results:
 %                   oo_.Smoother.SteadyState: Steady states (declaration order)
-%                   oo_.Smoother.TrendCoeffs: trend coefficients (order of options_.varobs)
+%                   oo_.Smoother.TrendCoeffs: trend coefficients, with NaN where no trend applies (declaration order)
 %                   oo_.Smoother.Variance: one-step ahead forecast error variance (declaration order)
 %                   oo_.Smoother.Constant: structure storing the constant term of the smoother
 %                   oo_.Smoother.Trend: structure storing the trend term of the smoother
@@ -77,7 +77,9 @@ end
 oo_.Smoother.SteadyState = ys;
 
 %% write trend coefficients and trend
-oo_.Smoother.TrendCoeffs = trend_coeff; %are in order of options_.varobs
+oo_.Smoother.TrendCoeffs = zeros(size(ys));
+
+oo_.Smoother.TrendCoeffs(options_.varobs_id)=trend_coeff; %are in order of options_.varobs
 
 if ~isempty(Trend)
     for var_iter=1:size(options_.varobs,2)

--- a/tests/TeX/fs2000_corr_ME.mod
+++ b/tests/TeX/fs2000_corr_ME.mod
@@ -144,7 +144,7 @@ stderr gy_obs, 1;
 corr gp_obs, gy_obs,0;
 end;
 
-estimation(order=1,datafile='../fs2000/fsdat_simul',mode_check,smoother,filter_decomposition,forecast = 8,filtered_vars,filter_step_ahead=[1,3],irf=20,contemporaneous_correlation) m P c e W R k d y gy_obs;
+estimation(order=1,datafile='../fs2000/fsdat_simul',mode_check,smoother,filter_covariance,filter_decomposition,forecast = 8,filtered_vars,filter_step_ahead=[1,3],irf=20,contemporaneous_correlation) m P c e W R k d y gy_obs;
 
 
 


### PR DESCRIPTION
- Saves trend and constant term in smoother after MCMC (Closes #1147)
- Save `oo_.Smoother.TrendCoeffs` for all variables instead of just observed (First part of #1162)
- Enables `filter_covariance` after MCMC (Closes #1160)


