### PR TITLE
Various fixes related to Ramsey with instruments

### DIFF
--- a/matlab/dsge_likelihood.m
+++ b/matlab/dsge_likelihood.m
@@ -266,7 +266,7 @@ end
 if info(1)
     if info(1) == 3 || info(1) == 4 || info(1) == 5 || info(1)==6 ||info(1) == 19 ||...
             info(1) == 20 || info(1) == 21 || info(1) == 23 || info(1) == 26 || ...
-            info(1) == 81 || info(1) == 84 ||  info(1) == 85
+            info(1) == 81 || info(1) == 84 ||  info(1) == 85 ||  info(1) == 86
         %meaningful second entry of output that can be used
         fval = Inf;
         info(4) = info(2);

--- a/matlab/dyn_ramsey_static.m
+++ b/matlab/dyn_ramsey_static.m
@@ -13,7 +13,7 @@ function [steady_state,params,check] = dyn_ramsey_static(ys_init,M,options_,oo)
 %    steady_state:  steady state value
 %    params:        parameters at steady state, potentially updated by
 %                   steady_state file
-%    check:         Lagrangian multipliers
+%    check:         error indicator, 0 if everything is OK
 %
 % SPECIAL REQUIREMENTS
 %    none

--- a/matlab/dynare_solve.m
+++ b/matlab/dynare_solve.m
@@ -46,6 +46,13 @@ else
     tolf = options.solve_tolf;
 end
 
+if strcmp(stack(2).file,'dyn_ramsey_static.m')
+    maxit = options.ramsey.maxit;
+else
+    maxit = options.steady.maxit;
+end
+
+
 info = 0;
 nn = size(x,1);
 
@@ -84,7 +91,7 @@ if options.solve_algo == 0
     end
     options4fsolve=optimset('fsolve');
     options4fsolve.MaxFunEvals = 50000;
-    options4fsolve.MaxIter = options.steady.maxit;
+    options4fsolve.MaxIter = maxit;
     options4fsolve.TolFun = tolf;
     options4fsolve.Display = 'iter';
     if jacobian_flag
@@ -132,11 +139,11 @@ if options.solve_algo == 0
 elseif options.solve_algo == 1
         [x,info]=solve1(func,x,1:nn,1:nn,jacobian_flag,options.gstep, ...
                     tolf,options.solve_tolx, ...
-                    options.steady.maxit,options.debug,varargin{:});
+                    maxit,options.debug,varargin{:});
 elseif options.solve_algo == 9
         [x,info]=trust_region(func,x,1:nn,1:nn,jacobian_flag,options.gstep, ...
                     tolf,options.solve_tolx, ...
-                    options.steady.maxit,options.debug,varargin{:});
+                    maxit,options.debug,varargin{:});
 elseif options.solve_algo == 2 || options.solve_algo == 4
 
     if options.solve_algo == 2
@@ -168,7 +175,7 @@ elseif options.solve_algo == 2 || options.solve_algo == 4
         [x,info]=solver(func,x,j1(r(i):r(i+1)-1),j2(r(i):r(i+1)-1),jacobian_flag, ...
                         options.gstep, ...
                         tolf,options.solve_tolx, ...
-                        options.steady.maxit,options.debug,varargin{:});
+                        maxit,options.debug,varargin{:});
         if info
             return
         end
@@ -177,7 +184,7 @@ elseif options.solve_algo == 2 || options.solve_algo == 4
     if max(abs(fvec)) > tolf
         [x,info]=solver(func,x,1:nn,1:nn,jacobian_flag, ...
                         options.gstep, tolf,options.solve_tolx, ...
-                        options.steady.maxit,options.debug,varargin{:});
+                        maxit,options.debug,varargin{:});
     end
 elseif options.solve_algo == 3
     if jacobian_flag

--- a/matlab/evaluate_steady_state.m
+++ b/matlab/evaluate_steady_state.m
@@ -136,7 +136,7 @@ function [ys,params,info] = evaluate_steady_state(ys_init,M,options,oo,steadysta
         %check whether steady state really solves the model
         resids = evaluate_static_model(ys,exo_ss,params,M,options);
 
-        n_multipliers=M.orig_eq_nbr;
+        n_multipliers=M.ramsey_eq_nbr;
         nan_indices_multiplier=find(isnan(resids(1:n_multipliers)));
         nan_indices=find(isnan(resids(n_multipliers+1:end)));
 

--- a/matlab/evaluate_steady_state.m
+++ b/matlab/evaluate_steady_state.m
@@ -145,7 +145,6 @@ function [ys,params,info] = evaluate_steady_state(ys_init,M,options,oo,steadysta
         %either if no steady state file or steady state file without problems
         [ys,params,info] = dyn_ramsey_static(ys_init,M,options,oo);
         if info
-           info=81;%case should not happen
            return;
         end
         %check whether steady state really solves the model

--- a/matlab/evaluate_steady_state.m
+++ b/matlab/evaluate_steady_state.m
@@ -176,7 +176,7 @@ function [ys,params,info] = evaluate_steady_state(ys_init,M,options,oo,steadysta
             fprintf('\nevaluate_steady_state: The steady state for the Ramsey problem could not be computed.\n')
             fprintf('evaluate_steady_state: The steady state computation stopped with the following instrument values:: \n')
             for i = 1:size(options.instruments,1);
-                fprintf('\t %s \t %f \n',options.instruments(i,:),ys_init(strmatch(options.instruments(i,:),M.endo_names,'exact')))
+                fprintf('\t %s \t %f \n',options.instruments(i,:),ys(strmatch(options.instruments(i,:),M.endo_names,'exact')))
             end
             fprintf('evaluate_steady_state: The following equations have non-zero residuals: \n')
             for ii=1:n_multipliers

--- a/matlab/evaluate_steady_state.m
+++ b/matlab/evaluate_steady_state.m
@@ -54,17 +54,6 @@ function [ys,params,info] = evaluate_steady_state(ys_init,M,options,oo,steadysta
     end
 
     if options.ramsey_policy
-        %test whether specification matches
-        inst_nbr = size(options.instruments,1);
-        if inst_nbr~=0
-            orig_endo_aux_nbr = M.orig_endo_nbr + min(find([M.aux_vars.type] == 6)) - 1;
-            implied_inst_nbr = orig_endo_aux_nbr - M.orig_eq_nbr;
-            if inst_nbr>implied_inst_nbr
-                error('You have specified more instruments than there are omitted equations')
-            elseif inst_nbr<implied_inst_nbr
-                error('You have specified fewer instruments than there are omitted equations')
-            end
-        end
         if steadystate_flag
             % explicit steady state file
             [ys,params,info] = evaluate_steady_state_file(ys_init,exo_ss,M, ...

--- a/matlab/evaluate_steady_state.m
+++ b/matlab/evaluate_steady_state.m
@@ -75,52 +75,56 @@ function [ys,params,info] = evaluate_steady_state(ys_init,M,options,oo,steadysta
             nan_indices=find(isnan(resids(n_multipliers+1:end)));
 
             if ~isempty(nan_indices)
-                fprintf('\nevaluate_steady_state: The steady state file computation for the Ramsey problem resulted in NaNs.\n')
-                fprintf('evaluate_steady_state: The steady state was computed conditional on the following initial instrument values: \n')
-                for ii = 1:size(options.instruments,1);
-                    fprintf('\t %s \t %f \n',options.instruments(ii,:),ys_init(strmatch(options.instruments(ii,:),M.endo_names,'exact')))
-                end
-                fprintf('evaluate_steady_state: The problem occured in the following equations: \n')
-                fprintf('\t Equation(s): ')
-                for ii=1:length(nan_indices)
+                if options.debug
+                    fprintf('\nevaluate_steady_state: The steady state file computation for the Ramsey problem resulted in NaNs.\n')
+                    fprintf('evaluate_steady_state: The steady state was computed conditional on the following initial instrument values: \n')
+                    for ii = 1:size(options.instruments,1);
+                        fprintf('\t %s \t %f \n',options.instruments(ii,:),ys_init(strmatch(options.instruments(ii,:),M.endo_names,'exact')))
+                    end
+                    fprintf('evaluate_steady_state: The problem occured in the following equations: \n')
+                    fprintf('\t Equation(s): ')
+                    for ii=1:length(nan_indices)
                         fprintf('%d, ',nan_indices(ii));
+                    end
+                    skipline();
+                    fprintf('evaluate_steady_state: If those initial values are not admissable, change them using an initval-block.\n')
+                    skipline(2);
                 end
-                skipline();
-                fprintf('evaluate_steady_state: If those initial values are not admissable, change them using an initval-block.\n')
-                skipline(2);
-                check=1;
                 info(1) = 84;
                 info(2) = resids'*resids;
                 return;
             end
             
             if any(imag(ys(n_multipliers+1:end)))
-                fprintf('\nevaluate_steady_state: The steady state file computation for the Ramsey problem resulted in complex numbers.\n')
-                fprintf('evaluate_steady_state: The steady state was computed conditional on the following initial instrument values: \n')
-                for ii = 1:size(options.instruments,1);
-                    fprintf('\t %s \t %f \n',options.instruments(ii,:),ys_init(strmatch(options.instruments(ii,:),M.endo_names,'exact')))
+                if options.debug
+                    fprintf('\nevaluate_steady_state: The steady state file computation for the Ramsey problem resulted in complex numbers.\n')
+                    fprintf('evaluate_steady_state: The steady state was computed conditional on the following initial instrument values: \n')
+                    for ii = 1:size(options.instruments,1);
+                        fprintf('\t %s \t %f \n',options.instruments(ii,:),ys_init(strmatch(options.instruments(ii,:),M.endo_names,'exact')))
+                    end
+                    fprintf('evaluate_steady_state: If those initial values are not admissable, change them using an initval-block.\n')
+                    skipline(2);
                 end
-                fprintf('evaluate_steady_state: If those initial values are not admissable, change them using an initval-block.\n')
-                skipline(2);
-                check=1;
                 info(1) = 86;
                 info(2) = resids'*resids;
                 return;
             end
 
             if max(abs(resids(n_multipliers+1:end))) > options.solve_tolf %does it solve for all variables except for the Lagrange multipliers
-                fprintf('\nevaluate_steady_state: The steady state file does not solve the steady state for the Ramsey problem.\n')
-                fprintf('evaluate_steady_state: Conditional on the following instrument values: \n')
-                for ii = 1:size(options.instruments,1);
-                    fprintf('\t %s \t %f \n',options.instruments(ii,:),ys_init(strmatch(options.instruments(ii,:),M.endo_names,'exact')))
-                end
-                fprintf('evaluate_steady_state: the following equations have non-zero residuals: \n')
-                for ii=n_multipliers+1:M.endo_nbr
-                    if abs(resids(ii)) > options.solve_tolf
-                        fprintf('\t Equation number %d: %f\n',ii-n_multipliers, resids(ii))
+                if options.debug
+                    fprintf('\nevaluate_steady_state: The steady state file does not solve the steady state for the Ramsey problem.\n')
+                    fprintf('evaluate_steady_state: Conditional on the following instrument values: \n')
+                    for ii = 1:size(options.instruments,1);
+                        fprintf('\t %s \t %f \n',options.instruments(ii,:),ys_init(strmatch(options.instruments(ii,:),M.endo_names,'exact')))
                     end
+                    fprintf('evaluate_steady_state: the following equations have non-zero residuals: \n')
+                    for ii=n_multipliers+1:M.endo_nbr
+                        if abs(resids(ii)) > options.solve_tolf
+                            fprintf('\t Equation number %d: %f\n',ii-n_multipliers, resids(ii))
+                        end
+                    end
+                    skipline(2);
                 end
-                skipline(2);
                 info(1) = 85;
                 info(2) = resids'*resids;
                 return;
@@ -155,55 +159,61 @@ function [ys,params,info] = evaluate_steady_state(ys_init,M,options,oo,steadysta
         nan_indices=find(isnan(resids(n_multipliers+1:end)));
 
         if ~isempty(nan_indices)
-            fprintf('\nevaluate_steady_state: The steady state computation for the Ramsey problem resulted in NaNs.\n')
-            fprintf('evaluate_steady_state: The steady state computation resulted in the following instrument values: \n')
-            for i = 1:size(options.instruments,1);
-                fprintf('\t %s \t %f \n',options.instruments(i,:),ys(strmatch(options.instruments(i,:),M.endo_names,'exact')))
-            end
-            fprintf('evaluate_steady_state: The problem occured in the following equations: \n')
-            fprintf('\t Equation(s): ')
-            for ii=1:length(nan_indices)
+            if options.debug
+                fprintf('\nevaluate_steady_state: The steady state computation for the Ramsey problem resulted in NaNs.\n')
+                fprintf('evaluate_steady_state: The steady state computation resulted in the following instrument values: \n')
+                for i = 1:size(options.instruments,1);
+                    fprintf('\t %s \t %f \n',options.instruments(i,:),ys(strmatch(options.instruments(i,:),M.endo_names,'exact')))
+                end
+                fprintf('evaluate_steady_state: The problem occured in the following equations: \n')
+                fprintf('\t Equation(s): ')
+                for ii=1:length(nan_indices)
                     fprintf('%d, ',nan_indices(ii));
+                end
+                skipline();
             end
-            skipline();
             info(1) = 82;
             return;
         end
 
         if ~isempty(nan_indices_multiplier)
-            fprintf('\nevaluate_steady_state: The steady state computation for the Ramsey problem resulted in NaNs in the auxiliary equations.\n')
-            fprintf('evaluate_steady_state: The steady state computation resulted in the following instrument values: \n')
-            for i = 1:size(options.instruments,1);
-                fprintf('\t %s \t %f \n',options.instruments(i,:),ys(strmatch(options.instruments(i,:),M.endo_names,'exact')))
-            end
-            fprintf('evaluate_steady_state: The problem occured in the following equations: \n')
-            fprintf('\t Auxiliary equation(s): ')
-            for ii=1:length(nan_indices_multiplier)
+            if options.debug
+                fprintf('\nevaluate_steady_state: The steady state computation for the Ramsey problem resulted in NaNs in the auxiliary equations.\n')
+                fprintf('evaluate_steady_state: The steady state computation resulted in the following instrument values: \n')
+                for i = 1:size(options.instruments,1);
+                    fprintf('\t %s \t %f \n',options.instruments(i,:),ys(strmatch(options.instruments(i,:),M.endo_names,'exact')))
+                end
+                fprintf('evaluate_steady_state: The problem occured in the following equations: \n')
+                fprintf('\t Auxiliary equation(s): ')
+                for ii=1:length(nan_indices_multiplier)
                     fprintf('%d, ',nan_indices_multiplier(ii));
+                end
+                skipline();
             end
-            skipline();
             info(1) = 83;
             return;
         end
 
         if max(abs(resids)) > options.solve_tolf %does it solve for all variables including the auxiliary ones
-            fprintf('\nevaluate_steady_state: The steady state for the Ramsey problem could not be computed.\n')
-            fprintf('evaluate_steady_state: The steady state computation stopped with the following instrument values:: \n')
-            for i = 1:size(options.instruments,1);
-                fprintf('\t %s \t %f \n',options.instruments(i,:),ys(strmatch(options.instruments(i,:),M.endo_names,'exact')))
-            end
-            fprintf('evaluate_steady_state: The following equations have non-zero residuals: \n')
-            for ii=1:n_multipliers
-                if abs(resids(ii)) > options.solve_tolf/100
-                    fprintf('\t Auxiliary Ramsey equation number %d: %f\n',ii, resids(ii))
+            if options.debug
+                fprintf('\nevaluate_steady_state: The steady state for the Ramsey problem could not be computed.\n')
+                fprintf('evaluate_steady_state: The steady state computation stopped with the following instrument values:: \n')
+                for i = 1:size(options.instruments,1);
+                    fprintf('\t %s \t %f \n',options.instruments(i,:),ys(strmatch(options.instruments(i,:),M.endo_names,'exact')))
                 end
-            end
-            for ii=n_multipliers+1:M.endo_nbr
-                if abs(resids(ii)) > options.solve_tolf/100
-                    fprintf('\t Equation number %d: %f\n',ii-n_multipliers, resids(ii))
+                fprintf('evaluate_steady_state: The following equations have non-zero residuals: \n')
+                for ii=1:n_multipliers
+                    if abs(resids(ii)) > options.solve_tolf/100
+                        fprintf('\t Auxiliary Ramsey equation number %d: %f\n',ii, resids(ii))
+                    end
                 end
+                for ii=n_multipliers+1:M.endo_nbr
+                    if abs(resids(ii)) > options.solve_tolf/100
+                        fprintf('\t Equation number %d: %f\n',ii-n_multipliers, resids(ii))
+                    end
+                end
+                skipline(2);
             end
-            skipline(2);
             info(1) = 81;
             info(2) = resids'*resids;
             return;

--- a/matlab/evaluate_steady_state.m
+++ b/matlab/evaluate_steady_state.m
@@ -93,6 +93,21 @@ function [ys,params,info] = evaluate_steady_state(ys_init,M,options,oo,steadysta
                 info(2) = resids'*resids;
                 return;
             end
+            
+            if any(imag(ys(n_multipliers+1:end)))
+                fprintf('\nevaluate_steady_state: The steady state file computation for the Ramsey problem resulted in complex numbers.\n')
+                fprintf('evaluate_steady_state: The steady state was computed conditional on the following initial instrument values: \n')
+                for ii = 1:size(options.instruments,1);
+                    fprintf('\t %s \t %f \n',options.instruments(ii,:),ys_init(strmatch(options.instruments(ii,:),M.endo_names,'exact')))
+                end
+                fprintf('evaluate_steady_state: If those initial values are not admissable, change them using an initval-block.\n')
+                skipline(2);
+                check=1;
+                info(1) = 86;
+                info(2) = resids'*resids;
+                return;
+            end
+
             if max(abs(resids(n_multipliers+1:end))) > options.solve_tolf %does it solve for all variables except for the Lagrange multipliers
                 fprintf('\nevaluate_steady_state: The steady state file does not solve the steady state for the Ramsey problem.\n')
                 fprintf('evaluate_steady_state: Conditional on the following instrument values: \n')

--- a/matlab/global_initialization.m
+++ b/matlab/global_initialization.m
@@ -346,6 +346,7 @@ options_.conditional_variance_decomposition = [];
 options_.ramsey_policy = 0;
 options_.instruments = [];
 options_.timeless = 0;
+options_.ramsey.maxit = 500;
 
 % estimation
 estimation_info.empty_prior = struct(...

--- a/matlab/initial_estimation_checks.m
+++ b/matlab/initial_estimation_checks.m
@@ -110,7 +110,21 @@ if info
     fprintf('The prior density evaluated at the initial values is Inf for the following parameters: %s\n',BayesInfo.name{info,1})
     error('The initial value of the prior is -Inf')
 end
-    
+
+if DynareOptions.ramsey_policy
+    %test whether specification matches
+    inst_nbr = size(DynareOptions.instruments,1);
+    if inst_nbr~=0
+        orig_endo_aux_nbr = Model.orig_endo_nbr + min(find([Model.aux_vars.type] == 6)) - 1;
+        implied_inst_nbr = orig_endo_aux_nbr - Model.orig_eq_nbr;
+        if inst_nbr>implied_inst_nbr
+            error('You have specified more instruments than there are omitted equations')
+        elseif inst_nbr<implied_inst_nbr
+            error('You have specified fewer instruments than there are omitted equations')
+        end
+    end
+end
+
 % Evaluate the likelihood.
 ana_deriv = DynareOptions.analytic_derivation;
 DynareOptions.analytic_derivation=0;

--- a/matlab/print_info.m
+++ b/matlab/print_info.m
@@ -148,6 +148,10 @@ if ~noprint
         error(['Ramsey: The steady state file computation for the Ramsey problem resulted in NaNs at the initial values of the instruments']);
       case 85
         error(['Ramsey: The steady state file does not solve the static first order conditions conditional on the instruments.']);
+      case 86
+        error(['Ramsey: The steady state file provides complex numbers conditional on the instruments.']);
+      case 87
+        error(['Ramsey: The maximum number of iterations has been reached. Try increasing maxit.']);
       case 102
         error('Aim: roots not correctly computed by real_schur');
       case 103

--- a/matlab/ramsey_policy.m
+++ b/matlab/ramsey_policy.m
@@ -22,6 +22,19 @@ global options_ oo_ M_
 options_.ramsey_policy = 1;
 oldoptions = options_;
 options_.order = 1;
+
+%test whether specification matches
+inst_nbr = size(options_.instruments,1);
+if inst_nbr~=0
+    orig_endo_aux_nbr = M_.orig_endo_nbr + min(find([M_.aux_vars.type] == 6)) - 1;
+    implied_inst_nbr = orig_endo_aux_nbr - M_.orig_eq_nbr;
+    if inst_nbr>implied_inst_nbr
+        error('You have specified more instruments than there are omitted equations')
+    elseif inst_nbr<implied_inst_nbr
+        error('You have specified fewer instruments than there are omitted equations')
+    end
+end
+        
 info = stoch_simul(var_list);
 
 oo_.steady_state = oo_.dr.ys;


### PR DESCRIPTION
- Fix display of instrument termination value in `evaluate_steady_state.m`
- Fix number of Lagrange multipliers in `evaluate_steady_state.m`
- Provide dedicated `maxit` option for Ramsey
- Add check for complex numbers in conditional steady state (prevents cryptic subsequent errors)
- Return with error if solution does not satisfy specified tolerance
- Suppress output unless explicitly requested (required for e.g. estimation, see #1173 )