### PR TITLE
Remove error-display from dynare_solve.m

### DIFF
--- a/matlab/display_problematic_vars_Jacobian.m
+++ b/matlab/display_problematic_vars_Jacobian.m
@@ -33,6 +33,7 @@ function []=display_problematic_vars_Jacobian(problemrow,problemcol,M_,x,type,ca
 % You should have received a copy of the GNU General Public License
 % along with Dynare.  If not, see <http://www.gnu.org/licenses/>.
 
+skipline();
 if nargin<6
     caller_string='';
 end
@@ -114,8 +115,8 @@ elseif strcmp(type,'static')
         end
     end
     fprintf('\n%s  The problem most often occurs, because a variable with\n',caller_string)
-    fprintf('%s exponent smaller than 1 has been initialized to 0. Taking the derivative\n',caller_string)
-    fprintf('%s and evaluating it at the steady state then results in a division by 0.\n',caller_string)
+    fprintf('%s  exponent smaller than 1 has been initialized to 0. Taking the derivative\n',caller_string)
+    fprintf('%s  and evaluating it at the steady state then results in a division by 0.\n',caller_string)
     fprintf('%s  If you are using model-local variables (# operator), check their values as well.\n',caller_string)
 else
     error('Unknown Type')    

--- a/matlab/dynare_solve.m
+++ b/matlab/dynare_solve.m
@@ -1,5 +1,5 @@
 function [x,info,fvec,fjac] = dynare_solve(func,x,options,varargin)
-% function [x,info] = dynare_solve(func,x,options,varargin)
+% function [x,info,fvec,fjac] = dynare_solve(func,x,options,varargin)
 % proposes different solvers
 %
 % INPUTS
@@ -11,6 +11,8 @@ function [x,info,fvec,fjac] = dynare_solve(func,x,options,varargin)
 % OUTPUTS
 %    x:                solution
 %    info=1:           the model can not be solved
+%    fvec:             Function value (used for debugging when check=1)
+%    fjac:             Jacobian (used for debugging when check=1)
 %
 % SPECIAL REQUIREMENTS
 %    none

--- a/matlab/dynare_solve.m
+++ b/matlab/dynare_solve.m
@@ -1,4 +1,4 @@
-function [x,info] = dynare_solve(func,x,options,varargin)
+function [x,info,fvec,fjac] = dynare_solve(func,x,options,varargin)
 % function [x,info] = dynare_solve(func,x,options,varargin)
 % proposes different solvers
 %
@@ -51,11 +51,9 @@ nn = size(x,1);
 if jacobian_flag
     [fvec,fjac] = feval(func,x,varargin{:});
     if any(any(isinf(fjac) | isnan(fjac)))
-        [infrow,infcol]=find(isinf(fjac) | isnan(fjac));
-        M=evalin('base','M_'); %get variable names from workspace
-        fprintf('\nSTEADY:  The Jacobian contains Inf or NaN. The problem arises from: \n\n')
-        display_problematic_vars_Jacobian(infrow,infcol,M,x,'static','STEADY: ')
-        error('An element of the Jacobian is not finite or NaN')
+        info=1;
+        x = NaN(size(fvec));
+        return
     end
 else
     fvec = feval(func,x,varargin{:});
@@ -65,12 +63,6 @@ end
 i = find(~isfinite(fvec));
 
 if ~isempty(i)
-    disp(['STEADY:  numerical initial values or parameters incompatible with the following' ...
-          ' equations'])
-    disp(i')
-    disp('Please check for example')
-    disp('   i) if all parameters occurring in these equations are defined')
-    disp('  ii) that no division by an endogenous variable initialized to 0 occurs')
     info = 1;
     x = NaN(size(fvec));
     return;

--- a/matlab/evaluate_steady_state.m
+++ b/matlab/evaluate_steady_state.m
@@ -213,6 +213,25 @@ function [ys,params,info] = evaluate_steady_state(ys_init,M,options,oo,steadysta
                                       options, exo_ss, params,...
                                       M.orig_endo_nbr,...
                                       static_model);
+            if check && options.debug
+                [ys,check,fvec,fjac] = dynare_solve(@static_problem,...
+                          ys_init,...
+                          options, exo_ss, params,...
+                          M.orig_endo_nbr,...
+                          static_model);
+                [infrow,infcol]=find(isinf(fjac) | isnan(fjac));
+                fprintf('\nSTEADY:  The Jacobian at the initial values contains Inf or NaN. The problem arises from: \n')
+                display_problematic_vars_Jacobian(infrow,infcol,M,ys_init,'static','STEADY: ')
+                
+                problematic_equation = find(~isfinite(fvec));                
+                if ~isempty(problematic_equation)
+                    fprintf('\nSTEADY:  numerical initial values or parameters incompatible with the following equations\n')
+                    disp(problematic_equation')
+                    fprintf('Please check for example\n')
+                    fprintf('   i) if all parameters occurring in these equations are defined\n')
+                    fprintf('  ii) that no division by an endogenous variable initialized to 0 occurs\n')
+                end
+            end
         else
             % linear model
             fh_static = str2func([M.fname '_static']);


### PR DESCRIPTION
Prevents estimation crashing when invalid starting values for steady state computation arise during e.g. mode-finding