### PR TITLE
Account for Matlab 2016b in installer and mex-folder

### DIFF
--- a/m4/ax_matlab_version.m4
+++ b/m4/ax_matlab_version.m4
@@ -22,6 +22,9 @@ AC_REQUIRE([AX_MATLAB])
 AC_MSG_CHECKING([for MATLAB version])
 if test "x$MATLAB_VERSION" != "x"; then
   case $MATLAB_VERSION in
+    *2016b | *2016B)
+      MATLAB_VERSION="9.1"
+      ;;
     *2016a | *2016A)
       MATLAB_VERSION="9.0"
       ;;

--- a/matlab/add_path_to_mex_files.m
+++ b/matlab/add_path_to_mex_files.m
@@ -48,7 +48,7 @@ else
                 end
             end
         else
-            tmp = [dynareroot '../mex/matlab/win64-7.8-9.0/'];
+            tmp = [dynareroot '../mex/matlab/win64-7.8-9.1/'];
             if exist(tmp, 'dir')
                 mexpath = tmp;
                 if modifypath

--- a/windows/dynare.nsi
+++ b/windows/dynare.nsi
@@ -98,9 +98,9 @@ Section "MEX files for MATLAB 64-bit, version 7.5 to 7.7 (R2007b to R2008b)"
  File ..\mex\matlab\win64-7.5-7.7\*.mexw64
 SectionEnd
 
-Section "MEX files for MATLAB 64-bit, version 7.8 to 9.0 (R2009a to R2016a)"
- SetOutPath $INSTDIR\mex\matlab\win64-7.8-9.0
- File ..\mex\matlab\win64-7.8-9.0\*.mexw64
+Section "MEX files for MATLAB 64-bit, version 7.8 to 9.1 (R2009a to R2016b)"
+ SetOutPath $INSTDIR\mex\matlab\win64-7.8-9.1
+ File ..\mex\matlab\win64-7.8-9.1\*.mexw64
 SectionEnd
 
 SectionGroupEnd


### PR DESCRIPTION
Might be necessary to also change `/usr/local/bin/make-dynare-win-unstable` on machine that generates snapshot, see #1183 