### PR TITLE
Tentative fix for osr example issue. Closes #1291

### DIFF
--- a/matlab/osr.m
+++ b/matlab/osr.m
@@ -51,7 +51,7 @@ oo_=make_ex_(M_,options_,oo_);
 np = size(params,1);
 i_params = zeros(np,1);
 for i=1:np
-    i_params(i) = strmatch(deblank(params(i,:)),M_.param_names,'exact');
+    i_params(i) = strmatch(cell2mat(deblank(params(i,:))),M_.param_names,'exact');
 end
 
 skipline()


### PR DESCRIPTION
In octave, deblank returns a cell object, however strmatch does not accept this. Including a cell2mat solved the problem for me. However I cannot test this in Matlab, to see if it breaks something.