### PR TITLE
Shock decomposition and posterior moments

### DIFF
--- a/doc/dynare.texi
+++ b/doc/dynare.texi
@@ -6829,6 +6829,12 @@ Metropolis has been run, @code{mle_mode} if MLE has been run.
 @xref{datafile}. Useful when computing the shock decomposition on a
 calibrated model.
 
+@item first_obs = @var{INTEGER}
+@xref{first_obs}.
+
+@item nobs = @var{INTEGER}
+@xref{nobs}.
+
 @item use_shock_groups [= @var{SHOCK_GROUPS_NAME}]
 @anchor{use_shock_groups}. Uses groups of shocks instead of individual shocks in
 the decomposition. Groups of shocks are defined in @xref{shock_groups} block.

--- a/matlab/pm3.m
+++ b/matlab/pm3.m
@@ -87,7 +87,8 @@ filter_step_ahead_indicator=0;
 filter_covar_indicator=0;
 
 for file = 1:ifil
-    load([DirectoryName '/' M_.fname var_type int2str(file)]);
+    loaded_file=load([DirectoryName '/' M_.fname var_type int2str(file)]);
+    stock=loaded_file.stock;
     if strcmp(var_type,'_filter_step_ahead')
         if file==1 %on first run, initialize variable for storing filter_step_ahead
             stock1_filter_step_ahead=NaN(n1,n2,B,length(options_.filter_step_ahead)); 

--- a/preprocessor/DynareBison.yy
+++ b/preprocessor/DynareBison.yy
@@ -2477,6 +2477,8 @@ shock_decomposition_option : o_parameter_set
                            | o_use_shock_groups
                            | o_colormap
                            | o_shock_decomposition_nograph
+                           | o_first_obs
+                           | o_nobs
                            ;
 
 homotopy_setup: HOMOTOPY_SETUP ';' homotopy_list END ';'


### PR DESCRIPTION
- Adds `first_obs` and `nobs` as options of `shock_decomposition`
- Restores compatibility of `pm3.m` with Matlab 2016b
