### PR TITLE
Make solve_algo=0 less and mode_check potentially more verbose

### DIFF
--- a/matlab/dynare_solve.m
+++ b/matlab/dynare_solve.m
@@ -93,7 +93,11 @@ if options.solve_algo == 0
     options4fsolve.MaxFunEvals = 50000;
     options4fsolve.MaxIter = maxit;
     options4fsolve.TolFun = tolf;
-    options4fsolve.Display = 'iter';
+    if options.debug==1
+        options4fsolve.Display = 'final';
+    else
+        options4fsolve.Display = 'off';
+    end
     if jacobian_flag
         options4fsolve.Jacobian = 'on';
     else

--- a/matlab/mode_check.m
+++ b/matlab/mode_check.m
@@ -145,6 +145,9 @@ for plt = 1:nbplt,
                 y(i,1) = fval;
             else
                 y(i,1) = NaN;
+                if DynareOptions.debug
+                    fprintf('mode_check:: could not solve model for parameter %s at value %4.3f, error code: %u\n',name,z(i),info(1))
+                end
             end
             if DynareOptions.mode_check.nolik==0
                 lnprior = priordens(xx,BayesInfo.pshape,BayesInfo.p6,BayesInfo.p7,BayesInfo.p3,BayesInfo.p4);


### PR DESCRIPTION
- Shuts off display of `solve_algo=0` unless debugging is requested. Otherwise, estimation will clutter the screen
- Displays reason for `mode_check`-problems when debugging is enabled
