### PR TITLE
Three bugfixes for missing_DiffuseKalmanSmootherH1_Z.m that led to wrong results

### DIFF
--- a/doc/dynare.texi
+++ b/doc/dynare.texi
@@ -5908,7 +5908,7 @@ Use the Univariate Diffuse Kalman Filter
 Default value is @code{0}. In case of missing observations of single or all series, Dynare treats those missing values as unobserved states and uses the Kalman filter to infer their value (see e.g. @cite{Durbin and Koopman (2012), Ch. 4.10})
 This procedure has the advantage of being capable of dealing with observations where the forecast error variance matrix becomes singular for some variable(s).
 If this happens, the respective observation enters with a weight of zero in the log-likelihood, i.e. this observation for the respective variable(s) is dropped
-from the likelihood computations (for details see @cite{Durbin and Koopman (2012), Ch. 6.4 and 7.2.5}). If the use of a multivariate Kalman filter is specified and a
+from the likelihood computations (for details see @cite{Durbin and Koopman (2012), Ch. 6.4 and 7.2.5} and @cite{Koopman and Durbin (2000)}). If the use of a multivariate Kalman filter is specified and a
 singularity is encountered, Dynare by default automatically switches to the univariate Kalman filter for this parameter draw. This behavior can be changed via the
 @ref{use_univariate_filters_if_singularity_is_detected} option.
 
@@ -5943,12 +5943,16 @@ Triggers the computation k-step ahead filtered values, i.e. @math{E_{t}{y_{t+k}}
 @anchor{filter_decomposition} Triggers the computation of the shock
 decomposition of the above k-step ahead filtered values. Stores results in @code{oo_.FilteredVariablesShockDecomposition}.
 
+@item smoothed_state_uncertainty
+@anchor{smoothed_state_uncertainty} Triggers the computation of the variance of smoothed estimates, i.e.
+@code{Var_T(y_t)}. Stores results in @code{oo_.Smoother.State_uncertainty}.
 
 @item diffuse_filter
 @anchor{diffuse_filter}
 Uses the diffuse Kalman filter (as described in
 @cite{Durbin and Koopman (2012)} and @cite{Koopman and Durbin
-(2003)}) to estimate models with non-stationary observed variables.
+(2003)} for the multivariate and @cite{Koopman and Durbin
+(2000)} for the univariate filter) to estimate models with non-stationary observed variables.
 
 When @code{diffuse_filter} is used the @code{lik_init} option of
 @code{estimation} has no effect.
@@ -6490,6 +6494,19 @@ from the Kalman smoother. The @code{M_.endo_nbr} times @code{M_.endo_nbr} times
 @code{T+1} array contains the variables in declaration order along the first 
 two dimensions. The third dimension of the array provides the
 observation for which the forecast has been made.
+@end defvr
+
+@defvr {MATLAB/Octave variable} oo_.Smoother.State_uncertainty
+@anchor{oo_.Smoother.State_uncertainty}
+Three-dimensional array set by the @code{estimation} command (if used with the
+@code{smoother}) without Metropolis, 
+or by the @code{calib_smoother} command, if the @code{o_smoothed_state_uncertainty} option
+has been requested.
+Contains the series of covariance matrices for the state estimate given the full data
+from the Kalman smoother. The @code{M_.endo_nbr} times @code{M_.endo_nbr} times
+@code{T} array contains the variables in declaration order along the first 
+two dimensions. The third dimension of the array provides the
+observation for which the smoothed estimate has been made.
 @end defvr
 
 @defvr {MATLAB/Octave variable} oo_.Smoother.SteadyState
@@ -14107,6 +14124,11 @@ Dynamics and Control}, 32(11), 3397--3414
 
 @item
 Koop, Gary (2003), @i{Bayesian Econometrics}, John Wiley & Sons
+
+@item
+Koopman, S. J. and J. Durbin (2000): ``Fast Filtering and Smoothing for 
+Multivariate State Space Models,'' @i{Journal of Time
+Series Analysis}, 21(3), 281--296
 
 @item
 Koopman, S. J. and J. Durbin (2003): ``Filtering and Smoothing of

--- a/matlab/dynare_estimation_1.m
+++ b/matlab/dynare_estimation_1.m
@@ -163,8 +163,8 @@ end
 
 if isequal(options_.mode_compute,0) && isempty(options_.mode_file) && options_.mh_posterior_mode_estimation==0
     if options_.smoother == 1
-        [atT,innov,measurement_error,updated_variables,ys,trend_coeff,aK,T,R,P,PK,decomp,Trend] = DsgeSmoother(xparam1,gend,transpose(data),data_index,missing_value);
-        [oo_]=store_smoother_results(M_,oo_,options_,bayestopt_,dataset_,dataset_info,atT,innov,measurement_error,updated_variables,ys,trend_coeff,aK,P,PK,decomp,Trend);
+        [atT,innov,measurement_error,updated_variables,ys,trend_coeff,aK,T,R,P,PK,decomp,Trend,state_uncertainty] = DsgeSmoother(xparam1,gend,transpose(data),data_index,missing_value);
+        [oo_]=store_smoother_results(M_,oo_,options_,bayestopt_,dataset_,dataset_info,atT,innov,measurement_error,updated_variables,ys,trend_coeff,aK,P,PK,decomp,Trend,state_uncertainty);
     end
     %reset qz_criterium
     options_.qz_criterium=qz_criterium_old;
@@ -483,8 +483,8 @@ if (~((any(bayestopt_.pshape > 0) && options_.mh_replic) || (any(bayestopt_.psha
                                                       > 0) && options_.load_mh_file)) ...
     || ~options_.smoother ) && options_.partial_information == 0  % to be fixed
     %% ML estimation, or posterior mode without Metropolis-Hastings or Metropolis without Bayesian smoothes variables
-    [atT,innov,measurement_error,updated_variables,ys,trend_coeff,aK,T,R,P,PK,decomp,Trend] = DsgeSmoother(xparam1,dataset_.nobs,transpose(dataset_.data),dataset_info.missing.aindex,dataset_info.missing.state);
-    [oo_,yf]=store_smoother_results(M_,oo_,options_,bayestopt_,dataset_,dataset_info,atT,innov,measurement_error,updated_variables,ys,trend_coeff,aK,P,PK,decomp,Trend);
+    [atT,innov,measurement_error,updated_variables,ys,trend_coeff,aK,T,R,P,PK,decomp,Trend,state_uncertainty] = DsgeSmoother(xparam1,dataset_.nobs,transpose(dataset_.data),dataset_info.missing.aindex,dataset_info.missing.state);
+    [oo_,yf]=store_smoother_results(M_,oo_,options_,bayestopt_,dataset_,dataset_info,atT,innov,measurement_error,updated_variables,ys,trend_coeff,aK,P,PK,decomp,Trend,state_uncertainty);
 
     if ~options_.nograph,
         [nbplt,nr,nc,lr,lc,nstar] = pltorg(M_.exo_nbr);

--- a/matlab/evaluate_smoother.m
+++ b/matlab/evaluate_smoother.m
@@ -97,9 +97,9 @@ if ischar(parameters)
     end
 end
 
-[atT,innov,measurement_error,updated_variables,ys,trend_coeff,aK,T,R,P,PK,decomp,Trend] = ...
+[atT,innov,measurement_error,updated_variables,ys,trend_coeff,aK,T,R,P,PK,decomp,Trend,state_uncertainty] = ...
     DsgeSmoother(parameters,dataset_.nobs,transpose(dataset_.data),dataset_info.missing.aindex,dataset_info.missing.state);
-[oo_]=store_smoother_results(M_,oo_,options_,bayestopt_,dataset_,dataset_info,atT,innov,measurement_error,updated_variables,ys,trend_coeff,aK,P,PK,decomp,Trend);
+[oo_]=store_smoother_results(M_,oo_,options_,bayestopt_,dataset_,dataset_info,atT,innov,measurement_error,updated_variables,ys,trend_coeff,aK,P,PK,decomp,Trend,state_uncertainty);
 
 if nargout==2
    Smoothed_variables_declaration_order_deviation_form=atT(oo_.dr.inv_order_var(bayestopt_.smoother_var_list),:);

--- a/matlab/global_initialization.m
+++ b/matlab/global_initialization.m
@@ -413,6 +413,7 @@ options_.bayesian_th_moments = 0;
 options_.diffuse_filter = 0;
 options_.filter_step_ahead = [];
 options_.filtered_vars = 0;
+options_.smoothed_state_uncertainty = 0;
 options_.first_obs = NaN;
 options_.nobs = NaN;
 options_.kalman_algo = 0;

--- a/matlab/imcforecast.m
+++ b/matlab/imcforecast.m
@@ -123,7 +123,9 @@ if estimated_model
     %store qz_criterium
     qz_criterium_old=options_.qz_criterium;
     options_=select_qz_criterium_value(options_);
+    options_state_uncertainty_old=options_.state_uncertainty;
     [atT,innov,measurement_error,filtered_state_vector,ys,trend_coeff,aK,T,R,P,PK,decomp,trend_addition] = DsgeSmoother(xparam,gend,data,data_index,missing_value);
+    options_.state_uncertainty=options_state_uncertainty_old;
     %get constant part
     if options_.noconstant
         constant = zeros(size(ys,1),options_cond_fcst.periods+1);

--- a/matlab/kalman/likelihood/kalman_filter_d.m
+++ b/matlab/kalman/likelihood/kalman_filter_d.m
@@ -97,7 +97,7 @@ while rank(Pinf,diffuse_kalman_tol) && (t<=last)
     else                                                                %F_{\infty,t} positive definite
         %To compare to DK (2012), this block makes use of the following transformation
         %Kstar=T^{-1}*K^{(1)}=M_{*}*F^{(1)}+M_{\infty}*F^{(2)}
-        %     =P_{*}*Z'*F^{(1)}+P_{\infty}*Z'*((-1)*(F_{\infty}^{-1})*F_{*}*(F_{\infty}^{-1}))
+        %     =P_{*}*Z'*F^{(1)}+P_{\infty}*Z'*((-1)*(-F_{\infty}^{-1})*F_{*}*(F_{\infty}^{-1}))
         %     =[P_{*}*Z'-Kinf*F_{*})]*F^{(1)}
         %Make use of L^{0}'=(T-K^{(0)}*Z)'=(T-T*M_{\infty}*F^{(1)}*Z)'
         %                  =(T-T*P_{\infty*Z'*F^{(1)}*Z)'=(T-T*Kinf*Z)'
@@ -108,7 +108,7 @@ while rank(Pinf,diffuse_kalman_tol) && (t<=last)
         iFinf  = inv(Finf);
         Kinf   = Pinf*Z'*iFinf;                                         %define Kinf=T^{-1}*K_0 with M_{\infty}=Pinf*Z'
         Fstar  = Z*Pstar*Z' + H;                                        %(5.7) DK(2012)
-        Kstar  = (Pstar*Z'-Kinf*Fstar)*iFinf;                           %(5.12) DK(2012)
+        Kstar  = (Pstar*Z'-Kinf*Fstar)*iFinf;                           %(5.12) DK(2012); note that there is a typo in DK (2003) with "+ Kinf" instead of "- Kinf", but it is correct in their appendix
         Pstar  = T*(Pstar-Pstar*Z'*Kinf'-Pinf*Z'*Kstar')*T'+QQ;         %(5.14) DK(2012)
         Pinf   = T*(Pinf-Pinf*Z'*Kinf')*T';                             %(5.14) DK(2012)
         a      = T*(a+Kinf*v);                                          %(5.13) DK(2012)

--- a/matlab/kalman/likelihood/kalman_filter_d.m
+++ b/matlab/kalman/likelihood/kalman_filter_d.m
@@ -87,7 +87,7 @@ while rank(Pinf,diffuse_kalman_tol) && (t<=last)
             else
                 iFstar = inv(Fstar);
                 dFstar = det(Fstar);
-                Kstar  = Pstar*Z'*iFstar;                               %(5.15) of DK (2012) with Kstar=K^(0)*T^{-1}
+                Kstar  = Pstar*Z'*iFstar;                               %(5.15) of DK (2012) with Kstar=T^{-1}*K^(0)
                 dlik(s)= log(dFstar) + v'*iFstar*v;                     %set w_t to bottom case in bottom equation page 172, DK (2012)
                 Pinf   = T*Pinf*transpose(T);                           % (5.16) DK (2012)
                 Pstar  = T*(Pstar-Pstar*Z'*Kstar')*T'+QQ;               % (5.17) DK (2012)
@@ -96,7 +96,7 @@ while rank(Pinf,diffuse_kalman_tol) && (t<=last)
         end
     else                                                                %F_{\infty,t} positive definite
         %To compare to DK (2012), this block makes use of the following transformation
-        %Kstar=K^{(1)}*T^{-1}=M_{*}*F^{(1)}+M_{\infty}*F^{(2)}
+        %Kstar=T^{-1}*K^{(1)}=M_{*}*F^{(1)}+M_{\infty}*F^{(2)}
         %     =P_{*}*Z'*F^{(1)}+P_{\infty}*Z'*((-1)*(F_{\infty}^{-1})*F_{*}*(F_{\infty}^{-1}))
         %     =[P_{*}*Z'-Kinf*F_{*})]*F^{(1)}
         %Make use of L^{0}'=(T-K^{(0)}*Z)'=(T-T*M_{\infty}*F^{(1)}*Z)'
@@ -106,7 +106,7 @@ while rank(Pinf,diffuse_kalman_tol) && (t<=last)
         %     =T*[(P_{\infty}*(-K^{(1)*Z}))+P_{*}*(I-Z'*Kinf')*T'+RQR]
         dlik(s)= log(det(Finf));                                        %set w_t to top case in bottom equation page 172, DK (2012)
         iFinf  = inv(Finf);
-        Kinf   = Pinf*Z'*iFinf;                                         %define Kinf=K_0*T^{-1} with M_{\infty}=Pinf*Z'
+        Kinf   = Pinf*Z'*iFinf;                                         %define Kinf=T^{-1}*K_0 with M_{\infty}=Pinf*Z'
         Fstar  = Z*Pstar*Z' + H;                                        %(5.7) DK(2012)
         Kstar  = (Pstar*Z'-Kinf*Fstar)*iFinf;                           %(5.12) DK(2012)
         Pstar  = T*(Pstar-Pstar*Z'*Kinf'-Pinf*Z'*Kstar')*T'+QQ;         %(5.14) DK(2012)

--- a/matlab/kalman/likelihood/missing_observations_kalman_filter_d.m
+++ b/matlab/kalman/likelihood/missing_observations_kalman_filter_d.m
@@ -106,10 +106,10 @@ while rank(Pinf,diffuse_kalman_tol) && (t<=last)
                 else
                     iFstar = inv(Fstar);
                     dFstar = det(Fstar);
-                    Kstar  = Pstar*ZZ'*iFstar;                              %(5.15) of DK (2012) with Kstar=K^(0)*T^{-1}
+                    Kstar  = Pstar*ZZ'*iFstar;                              %(5.15) of DK (2012) with Kstar=T^{-1}*K^(0)
                     dlik(s) = log(dFstar) + v'*iFstar*v + length(d_index)*log(2*pi);    %set w_t to bottom case in bottom equation page 172, DK (2012)
                     Pinf   = T*Pinf*transpose(T);                           % (5.16) DK (2012)
-                    Pstar  = T*(Pstar-Pstar*ZZ'*Kstar')*T'+QQ;              % (5.17) DK (2012)
+                    Pstar  = T*(Pstar-Pstar*ZZ'*Kstar')*T'+QQ;              % (5.17) DK (2012) with L_0 plugged in
                     a      = T*(a+Kstar*v);                                 % (5.13) DK (2012)
                 end
             end

--- a/matlab/kalman/likelihood/missing_observations_kalman_filter_d.m
+++ b/matlab/kalman/likelihood/missing_observations_kalman_filter_d.m
@@ -119,7 +119,7 @@ while rank(Pinf,diffuse_kalman_tol) && (t<=last)
             Kinf   = Pinf*ZZ'*iFinf;
             %see notes in kalman_filter_d.m for details of computations
             Fstar  = ZZ*Pstar*ZZ' + H(d_index,d_index);                     %(5.7) DK(2012)
-            Kstar  = (Pstar*ZZ'-Kinf*Fstar)*iFinf;                          %(5.12) DK(2012)
+            Kstar  = (Pstar*ZZ'-Kinf*Fstar)*iFinf;                          %(5.12) DK(2012); note that there is a typo in DK (2003) with "+ Kinf" instead of "- Kinf", but it is correct in their appendix
             Pstar  = T*(Pstar-Pstar*ZZ'*Kinf'-Pinf*ZZ'*Kstar')*T'+QQ;       %(5.14) DK(2012)
             Pinf   = T*(Pinf-Pinf*ZZ'*Kinf')*T';                            %(5.14) DK(2012)
             a      = T*(a+Kinf*v);                                          %(5.13) DK(2012)

--- a/matlab/missing_DiffuseKalmanSmootherH1_Z.m
+++ b/matlab/missing_DiffuseKalmanSmootherH1_Z.m
@@ -131,8 +131,8 @@ while rank(Pinf(:,:,t+1),diffuse_kalman_tol) && t<smpl
                         Pinf(:,:,t+1)  = T*Pinf(:,:,t)*transpose(T);
                     end
                 else
-                    iFstar = inv(Fstar(:,:,t));
-                    Kstar(:,:,t)  = Pstar(:,:,t)*ZZ'*iFstar;         %(5.15) of DK (2012) with Kstar=T^{-1}*K^(0)
+                    iFstar          = inv(Fstar(:,:,t));
+                    Kstar(:,:,t)    = Pstar(:,:,t)*ZZ'*iFstar;         %(5.15) of DK (2012) with Kstar=T^{-1}*K^(0)
                     Pinf(:,:,t+1)   = T*Pinf(:,:,t)*transpose(T);           % DK (2012), 5.16
                     Pstar(:,:,t+1)  = T*(Pstar(:,:,t)-Pstar(:,:,t)*ZZ'*Kstar(:,:,t)')*T'+QQ;    % (5.17) DK (2012) with L_0 plugged in
                     a(:,t+1)        = T*(a(:,t)+Kstar(:,:,t)*v(:,t));       % (5.13) DK (2012)
@@ -161,7 +161,6 @@ d = t;
 P(:,:,d+1) = Pstar(:,:,d+1);
 iFinf = iFinf(:,:,1:d);
 Linf  = Linf(:,:,1:d);
-Fstar = Fstar(:,:,1:d);
 Kstar = Kstar(:,:,1:d);
 Pstar = Pstar(:,:,1:d);
 Pinf  = Pinf(:,:,1:d);

--- a/matlab/missing_DiffuseKalmanSmootherH1_Z.m
+++ b/matlab/missing_DiffuseKalmanSmootherH1_Z.m
@@ -132,7 +132,7 @@ while rank(Pinf(:,:,t+1),diffuse_kalman_tol) && t<smpl
                     end
                 else
                     iFstar = inv(Fstar(:,:,t));
-                    Kstar(:,:,t)  = Pstar(:,:,t)*ZZ'*iFstar(:,:,t);         %(5.15) of DK (2012) with Kstar=T^{-1}*K^(0)
+                    Kstar(:,:,t)  = Pstar(:,:,t)*ZZ'*iFstar;                %(5.15) of DK (2012) with Kstar=T^{-1}*K^(0)
                     Pinf(:,:,t+1)   = T*Pinf(:,:,t)*transpose(T);           % DK (2012), 5.16
                     Pstar(:,:,t+1)  = T*(Pstar(:,:,t)-Pstar(:,:,t)*ZZ'*Kstar(:,:,t)')*T'+QQ;    % (5.17) DK (2012) with L_0 plugged in
                     a(:,t+1)        = T*(a(:,t)+Kstar(:,:,t)*v(:,t));       % (5.13) DK (2012)

--- a/matlab/missing_DiffuseKalmanSmootherH1_Z.m
+++ b/matlab/missing_DiffuseKalmanSmootherH1_Z.m
@@ -132,7 +132,7 @@ while rank(Pinf(:,:,t+1),diffuse_kalman_tol) && t<smpl
                     end
                 else
                     iFstar = inv(Fstar(:,:,t));
-                    Kstar(:,:,t)  = Pstar(:,:,t)*ZZ'*iFstar;                %(5.15) of DK (2012) with Kstar=T^{-1}*K^(0)
+                    Kstar(:,:,t)  = Pstar(:,:,t)*ZZ'*iFstar;         %(5.15) of DK (2012) with Kstar=T^{-1}*K^(0)
                     Pinf(:,:,t+1)   = T*Pinf(:,:,t)*transpose(T);           % DK (2012), 5.16
                     Pstar(:,:,t+1)  = T*(Pstar(:,:,t)-Pstar(:,:,t)*ZZ'*Kstar(:,:,t)')*T'+QQ;    % (5.17) DK (2012) with L_0 plugged in
                     a(:,t+1)        = T*(a(:,t)+Kstar(:,:,t)*v(:,t));       % (5.13) DK (2012)
@@ -145,7 +145,7 @@ while rank(Pinf(:,:,t+1),diffuse_kalman_tol) && t<smpl
             atilde(:,t)     = a(:,t) + Kinf(:,di,t)*v(di,t);
             Linf(:,:,t)     = T - T*Kinf(:,di,t)*ZZ;                        %L^(0) in DK (2012), eq. 5.12
             Fstar(di,di,t)  = ZZ*Pstar(:,:,t)*ZZ' + H(di,di);               %(5.7) DK(2012)
-            Kstar(:,di,t)   = (Pstar(:,:,t)*ZZ'-Kinf(:,di,t)*Fstar(di,di,t))*iFinf(di,di,t); %(5.12) DK(2012) with Kstar=T^{-1}*K^(1)
+            Kstar(:,di,t)   = (Pstar(:,:,t)*ZZ'-Kinf(:,di,t)*Fstar(di,di,t))*iFinf(di,di,t); %(5.12) DK(2012) with Kstar=T^{-1}*K^(1); note that there is a typo in DK (2003) with "+ Kinf" instead of "- Kinf", but it is correct in their appendix
             Pstar(:,:,t+1)  = T*(Pstar(:,:,t)-Pstar(:,:,t)*ZZ'*Kinf(:,di,t)'-Pinf(:,:,t)*ZZ'*Kstar(:,di,t)')*T' + QQ; %(5.14) DK(2012)
             Pinf(:,:,t+1)   = T*(Pinf(:,:,t)-Pinf(:,:,t)*ZZ'*Kinf(:,di,t)')*T';     %(5.14) DK(2012)
         end

--- a/matlab/pm3.m
+++ b/matlab/pm3.m
@@ -85,6 +85,7 @@ fprintf(['Estimation::mcmc: ' tit1 '\n']);
 k = 0;
 filter_step_ahead_indicator=0;
 filter_covar_indicator=0;
+state_uncert_indicator=0;
 
 for file = 1:ifil
     loaded_file=load([DirectoryName '/' M_.fname var_type int2str(file)]);
@@ -118,6 +119,13 @@ for file = 1:ifil
         end
         k = k(end)+(1:size(stock,2));
         stock1(:,k) = stock;
+    elseif strcmp(var_type,'_state_uncert')
+        if file==1 %on first run, initialize variable for storing filter_step_ahead
+            stock1_state_uncert=NaN(n1,n2,size(stock,3),B);
+        end
+        state_uncert_indicator=1;
+        k = k(end)+(1:size(stock,4));
+        stock1_state_uncert(:,:,:,k) = stock;
     else
         if file==1 %on first run, initialize variable for storing filter_step_ahead
             stock1 = zeros(n1,n2,B);
@@ -138,8 +146,7 @@ if filter_step_ahead_indicator
     if options_.estimation.moments_posterior_density.indicator
         Density_filter_step_ahead = zeros(options_.estimation.moments_posterior_density.gridpoints,2,filter_steps,nvar,n2);
     end
-end
-if filter_covar_indicator
+elseif filter_covar_indicator
     draw_dimension=4;
     oo_.FilterCovariance.Mean = squeeze(mean(stock1_filter_covar,draw_dimension));
     oo_.FilterCovariance.Median = squeeze(median(stock1_filter_covar,draw_dimension));
@@ -159,6 +166,28 @@ if filter_covar_indicator
     oo_.FilterCovariance.post_deciles=post_deciles;
     oo_.FilterCovariance.HPDinf=squeeze(hpd_interval(:,:,:,1));
     oo_.FilterCovariance.HPDsup=squeeze(hpd_interval(:,:,:,2));
+    fprintf(['Estimation::mcmc: ' tit1 ', done!\n']);
+    return
+elseif state_uncert_indicator
+    draw_dimension=4;
+    oo_.Smoother.State_uncertainty.Mean = squeeze(mean(stock1_state_uncert,draw_dimension));
+    oo_.Smoother.State_uncertainty.Median = squeeze(median(stock1_state_uncert,draw_dimension));
+    oo_.Smoother.State_uncertainty.var = squeeze(var(stock1_state_uncert,0,draw_dimension));
+    if size(stock1_state_uncert,draw_dimension)>2
+        hpd_interval = quantile(stock1_state_uncert,[(1-options_.mh_conf_sig)/2 (1-options_.mh_conf_sig)/2+options_.mh_conf_sig],draw_dimension);
+    else
+        size_matrix=size(stock1_state_uncert);
+        hpd_interval=NaN([size_matrix(1:3),2]);
+    end
+    if size(stock1_state_uncert,draw_dimension)>9
+        post_deciles =quantile(stock1_state_uncert,[0.1:0.1:0.9],draw_dimension);
+    else
+        size_matrix=size(stock1_state_uncert);
+        post_deciles=NaN([size_matrix(1:3),9]);
+    end
+    oo_.Smoother.State_uncertainty.post_deciles=post_deciles;
+    oo_.Smoother.State_uncertainty.HPDinf=squeeze(hpd_interval(:,:,:,1));
+    oo_.Smoother.State_uncertainty.HPDsup=squeeze(hpd_interval(:,:,:,2));
     fprintf(['Estimation::mcmc: ' tit1 ', done!\n']);
     return
 end

--- a/matlab/store_smoother_results.m
+++ b/matlab/store_smoother_results.m
@@ -1,4 +1,4 @@
-function [oo_, yf]=store_smoother_results(M_,oo_,options_,bayestopt_,dataset_,dataset_info,atT,innov,measurement_error,updated_variables,ys,trend_coeff,aK,P,PK,decomp,Trend)
+function [oo_, yf]=store_smoother_results(M_,oo_,options_,bayestopt_,dataset_,dataset_info,atT,innov,measurement_error,updated_variables,ys,trend_coeff,aK,P,PK,decomp,Trend,state_uncertainty)
 % oo_=store_smoother_results(M_,oo_,options_,bayestopt_,dataset_,atT,innov,measurement_error,updated_variables,ys,trend_coeff,aK,P,PK,decomp,Trend)
 % Writes the smoother results into respective fields in oo_
 % 
@@ -24,6 +24,8 @@ function [oo_, yf]=store_smoother_results(M_,oo_,options_,bayestopt_,dataset_,da
 %   decomp          [4D array]  (K*m*r*(T+K)) 4D array of shock decomposition of k-step ahead
 %                                   filtered variables (decision-rule order)
 %   Trend           [double]    [nvarobs*T] matrix of trends in observables
+%   state_uncertainty [double]   (K,K,T) array, storing the uncertainty
+%                                   about the smoothed state (decision-rule order)
 %
 % Outputs:
 %   oo_             [structure] storing the results:
@@ -38,7 +40,8 @@ function [oo_, yf]=store_smoother_results(M_,oo_,options_,bayestopt_,dataset_,da
 %                   oo_.UpdatedVariables: structure storing the updated variables
 %                   oo_.SmoothedShocks: structure storing the smoothed shocks
 %                   oo_.SmoothedMeasurementErrors: structure storing the smoothed measurement errors
-%
+%                   oo_.Smoother.State_uncertainty: smoothed state uncertainty (declaration order)
+
 %   yf              [double]    (nvarobs*T) matrix storing the smoothed observed variables (order of options_.varobs)  
 % 
 % Notes: 
@@ -117,6 +120,9 @@ if options_.filter_covariance
     oo_.Smoother.Variance = P;
 end
 
+if options_.smoothed_state_uncertainty
+    oo_.Smoother.State_uncertainty=state_uncertainty;
+end
 %get indices of smoothed variables
 i_endo_in_bayestopt_smoother_varlist = bayestopt_.smoother_saved_var_list;
 i_endo_in_dr_matrices=bayestopt_.smoother_var_list(i_endo_in_bayestopt_smoother_varlist);
@@ -206,6 +212,9 @@ end
 
 if options_.filter_covariance
     oo_.Smoother.Variance(oo_.dr.order_var,oo_.dr.order_var,:)=oo_.Smoother.Variance;
+end
+if options_.smoothed_state_uncertainty
+    oo_.Smoother.State_uncertainty(oo_.dr.order_var,oo_.dr.order_var,:)=state_uncertainty;
 end
 
 %% get smoothed shocks

--- a/preprocessor/DynareBison.yy
+++ b/preprocessor/DynareBison.yy
@@ -153,7 +153,7 @@ class ParsingDriver;
 %token <string_val> ALPHA BETA ABAND NINV CMS NCMS CNUM GAMMA INV_GAMMA INV_GAMMA1 INV_GAMMA2 NORMAL UNIFORM EPS PDF FIG DR NONE PRIOR PRIOR_VARIANCE HESSIAN IDENTITY_MATRIX DIRICHLET
 %token GSIG2_LMDM Q_DIAG FLAT_PRIOR NCSK NSTD WEIBULL WEIBULL_PDF
 %token INDXPARR INDXOVR INDXAP APBAND INDXIMF IMFBAND INDXFORE FOREBAND INDXGFOREHAT INDXGIMFHAT
-%token INDXESTIMA INDXGDLS EQ_MS FILTER_COVARIANCE FILTER_DECOMPOSITION
+%token INDXESTIMA INDXGDLS EQ_MS FILTER_COVARIANCE FILTER_DECOMPOSITION SMOOTHED_STATE_UNCERTAINTY
 %token EQ_CMS TLINDX TLNUMBER BANACT RESTRICTIONS POSTERIOR_SAMPLER_OPTIONS
 %token OUTPUT_FILE_TAG DRAWS_NBR_BURN_IN_1 DRAWS_NBR_BURN_IN_2 HORIZON
 %token SBVAR TREND_VAR DEFLATOR GROWTH_FACTOR MS_IRF MS_VARIANCE_DECOMPOSITION
@@ -1777,6 +1777,7 @@ estimation_options : o_datafile
                    | o_partial_information
                    | o_filter_covariance
                    | o_filter_decomposition
+                   | o_smoothed_state_uncertainty
                    | o_selected_variables_only
                    | o_conditional_variance_decomposition
                    | o_cova_compute
@@ -2581,6 +2582,7 @@ calib_smoother_option : o_filtered_vars
                       | o_filter_decomposition
                       | o_diffuse_kalman_tol
                       | o_diffuse_filter
+                      | o_smoothed_state_uncertainty
                       ;
 
 extended_path : EXTENDED_PATH ';'
@@ -3128,6 +3130,9 @@ o_filter_covariance : FILTER_COVARIANCE
                       ;
 o_filter_decomposition : FILTER_DECOMPOSITION
                            { driver.option_num("filter_decomposition","1");}
+                         ;
+o_smoothed_state_uncertainty : SMOOTHED_STATE_UNCERTAINTY
+                           { driver.option_num("smoothed_state_uncertainty","1");}
                          ;
 o_selected_variables_only : SELECTED_VARIABLES_ONLY
                            { driver.option_num("selected_variables_only","1");}

--- a/preprocessor/DynareFlex.ll
+++ b/preprocessor/DynareFlex.ll
@@ -573,6 +573,7 @@ DATE -?[0-9]+([YyAa]|[Mm]([1-9]|1[0-2])|[Qq][1-4]|[Ww]([1-9]{1}|[1-4][0-9]|5[0-2
 <DYNARE_STATEMENT>k_order_solver {return token::K_ORDER_SOLVER; }
 <DYNARE_STATEMENT>filter_covariance {return token::FILTER_COVARIANCE; }
 <DYNARE_STATEMENT>filter_decomposition {return token::FILTER_DECOMPOSITION; }
+<DYNARE_STATEMENT>smoothed_state_uncertainty {return token::SMOOTHED_STATE_UNCERTAINTY; }
 <DYNARE_STATEMENT>selected_variables_only {return token::SELECTED_VARIABLES_ONLY; }
 <DYNARE_STATEMENT>pruning {return token::PRUNING; }
 <DYNARE_STATEMENT>save_draws {return token::SAVE_DRAWS; }

--- a/tests/TeX/fs2000_corr_ME.mod
+++ b/tests/TeX/fs2000_corr_ME.mod
@@ -168,7 +168,8 @@ end;
 
 write_latex_prior_table;
 
-estimation(mode_compute=8,order=1,datafile='../fs2000/fsdat_simul',mode_check,smoother,filter_decomposition,mh_replic=4000, mh_nblocks=1, mh_jscale=0.8,forecast = 8,bayesian_irf,filtered_vars,filter_step_ahead=[1,3],irf=20,moments_varendo,contemporaneous_correlation,conditional_variance_decomposition=[1 2 4]) m P c e W R k d y gy_obs;
+estimation(mode_compute=8,order=1,datafile='../fs2000/fsdat_simul',mode_check,smoother,filter_decomposition,mh_replic=4000, mh_nblocks=1, mh_jscale=0.8,forecast = 8,bayesian_irf,filtered_vars,filter_step_ahead=[1,3],irf=20,
+        moments_varendo,contemporaneous_correlation,conditional_variance_decomposition=[1 2 4],smoothed_state_uncertainty) m P c e W R k d y gy_obs;
 
 trace_plot(options_,M_,estim_params_,'PosteriorDensity',1);
 trace_plot(options_,M_,estim_params_,'StructuralShock',1,'e_a')

--- a/tests/kalman_filter_smoother/algo1.mod
+++ b/tests/kalman_filter_smoother/algo1.mod
@@ -31,8 +31,8 @@ stderr e_z, uniform_pdf,,, 0.01, 0.1;
 end;
 
 varobs dw dx dy z;
-       
-estimation(datafile=data,first_obs=1000,nobs=200,mh_replic=0,filtered_vars);
+
+estimation(datafile=data,first_obs=1000,nobs=200,mh_replic=0,filtered_vars,smoothed_state_uncertainty);
 
 //checking smoother consistency
 X = oo_.SmoothedVariables;

--- a/tests/kalman_filter_smoother/algo2.mod
+++ b/tests/kalman_filter_smoother/algo2.mod
@@ -31,8 +31,8 @@ stderr e_z, uniform_pdf,,, 0.01, 0.1;
 end;
 
 varobs dw dx dy z;
-       
-estimation(datafile=data,first_obs=1000,nobs=200,mh_replic=0,mode_compute=0,mode_file=algo1_mode,kalman_algo=2,filtered_vars);
+
+estimation(datafile=data,first_obs=1000,nobs=200,mh_replic=0,mode_compute=0,mode_file=algo1_mode,kalman_algo=2,filtered_vars,smoothed_state_uncertainty);
 
 //checking smoother consistency
 X = oo_.SmoothedVariables;

--- a/tests/kalman_filter_smoother/algo3.mod
+++ b/tests/kalman_filter_smoother/algo3.mod
@@ -34,8 +34,8 @@ stderr e_z, inv_gamma_pdf,0.01, inf;
 end;
 
 varobs w x y;
-       
-estimation(datafile=data,first_obs=1000,nobs=200,mh_replic=0,diffuse_filter,filtered_vars);
+
+estimation(datafile=data,first_obs=1000,nobs=200,mh_replic=0,diffuse_filter,filtered_vars,smoothed_state_uncertainty);
 
 //checking smoother consistency
 X = oo_.SmoothedVariables;

--- a/tests/kalman_filter_smoother/algo4.mod
+++ b/tests/kalman_filter_smoother/algo4.mod
@@ -34,8 +34,8 @@ stderr e_z, inv_gamma_pdf,0.01, inf;
 end;
 
 varobs w x y;
-       
-estimation(datafile=data,first_obs=1000,nobs=200,mh_replic=0,mode_compute=0,mode_file=algo3_mode,diffuse_filter,kalman_algo=4,filtered_vars);
+
+estimation(datafile=data,first_obs=1000,nobs=200,mh_replic=0,mode_compute=0,mode_file=algo3_mode,diffuse_filter,kalman_algo=4,filtered_vars,smoothed_state_uncertainty);
 
 //checking smoother consistency
 X = oo_.SmoothedVariables;

--- a/tests/kalman_filter_smoother/algo4a.mod
+++ b/tests/kalman_filter_smoother/algo4a.mod
@@ -33,7 +33,7 @@ end;
 
 varobs dw dx y z;
        
-estimation(datafile=data,first_obs=1000,nobs=200,mh_replic=0,diffuse_filter);
+estimation(datafile=data,first_obs=1000,nobs=200,mh_replic=0,diffuse_filter,smoothed_state_uncertainty);
 //estimation(datafile=data,first_obs=1000,nobs=200,mh_replic=0,mode_compute=0,mode_file=algo3_mode,diffuse_filter);
 
 //checking smoother consistency

--- a/tests/kalman_filter_smoother/algo4b.mod
+++ b/tests/kalman_filter_smoother/algo4b.mod
@@ -33,7 +33,7 @@ end;
 
 varobs dw dx y z;
        
-estimation(datafile=data,first_obs=1000,nobs=200,mh_replic=0,diffuse_filter);
+estimation(datafile=data,first_obs=1000,nobs=200,mh_replic=0,diffuse_filter,smoothed_state_uncertainty);
 //estimation(datafile=data,first_obs=1000,nobs=200,mh_replic=0,mode_compute=0,mode_file=algo3_mode,diffuse_filter);
 
 //checking smoother consistency

--- a/tests/kalman_filter_smoother/algoH1.mod
+++ b/tests/kalman_filter_smoother/algoH1.mod
@@ -34,7 +34,7 @@ end;
 
 varobs dw dx dy z;
        
-estimation(datafile=data,first_obs=1000,nobs=200,mh_replic=0,filtered_vars);
+estimation(datafile=data,first_obs=1000,nobs=200,mh_replic=0,filtered_vars,smoothed_state_uncertainty);
 
 //checking smoother consistency
 X = oo_.SmoothedVariables;

--- a/tests/kalman_filter_smoother/algoH2.mod
+++ b/tests/kalman_filter_smoother/algoH2.mod
@@ -35,7 +35,7 @@ end;
 varobs dw dx dy z;
        
 //estimation(datafile=data,first_obs=1000,nobs=200,mh_replic=0,kalman_algo=2);
-estimation(datafile=data,first_obs=1000,nobs=200,mh_replic=0,mode_compute=0,mode_file=algoH1_mode,kalman_algo=2,filtered_vars);
+estimation(datafile=data,first_obs=1000,nobs=200,mh_replic=0,mode_compute=0,mode_file=algoH1_mode,kalman_algo=2,filtered_vars,smoothed_state_uncertainty);
 
 //checking smoother consistency
 X = oo_.SmoothedVariables;

--- a/tests/kalman_filter_smoother/algoH3.mod
+++ b/tests/kalman_filter_smoother/algoH3.mod
@@ -37,7 +37,7 @@ end;
 
 varobs w x y;
        
-estimation(datafile=data,first_obs=1000,nobs=200,mh_replic=0,diffuse_filter);
+estimation(datafile=data,first_obs=1000,nobs=200,mh_replic=0,diffuse_filter,smoothed_state_uncertainty);
 
 stoch_simul(irf=0);
 

--- a/tests/kalman_filter_smoother/fs2000_smoother_only.mod
+++ b/tests/kalman_filter_smoother/fs2000_smoother_only.mod
@@ -100,11 +100,11 @@ check;
 
 varobs gp_obs gy_obs;
 
-estimation(order=1, datafile=fsdat_simul, mode_compute=0,nobs=192, loglinear, smoother) m P c e W R k d n l gy_obs gp_obs y dA;
-estimation(order=1, datafile=fsdat_simul, mode_compute=0,nobs=192, loglinear, smoother,kalman_algo=1) m P c e W R k d n l gy_obs gp_obs y dA;
-estimation(order=1, datafile=fsdat_simul, mode_compute=0,nobs=192, loglinear, smoother,kalman_algo=2) m P c e W R k d n l gy_obs gp_obs y dA;
-estimation(order=1, datafile=fsdat_simul, mode_compute=0,nobs=192, loglinear, smoother,kalman_algo=3) m P c e W R k d n l gy_obs gp_obs y dA;
-estimation(order=1, datafile=fsdat_simul, mode_compute=0,nobs=192, loglinear, smoother,kalman_algo=4) m P c e W R k d n l gy_obs gp_obs y dA;
+estimation(order=1, datafile=fsdat_simul, mode_compute=0,nobs=192, loglinear, smoother, smoothed_state_uncertainty) m P c e W R k d n l gy_obs gp_obs y dA;
+estimation(order=1, datafile=fsdat_simul, mode_compute=0,nobs=192, loglinear, smoother,kalman_algo=1, smoothed_state_uncertainty) m P c e W R k d n l gy_obs gp_obs y dA;
+estimation(order=1, datafile=fsdat_simul, mode_compute=0,nobs=192, loglinear, smoother,kalman_algo=2, smoothed_state_uncertainty) m P c e W R k d n l gy_obs gp_obs y dA;
+estimation(order=1, datafile=fsdat_simul, mode_compute=0,nobs=192, loglinear, smoother,kalman_algo=3, smoothed_state_uncertainty) m P c e W R k d n l gy_obs gp_obs y dA;
+estimation(order=1, datafile=fsdat_simul, mode_compute=0,nobs=192, loglinear, smoother,kalman_algo=4, smoothed_state_uncertainty) m P c e W R k d n l gy_obs gp_obs y dA;
 
 /*
  * The following lines were used to generate the data file. If you want to

--- a/tests/kalman_filter_smoother/fs2000_smoother_only_ns.mod
+++ b/tests/kalman_filter_smoother/fs2000_smoother_only_ns.mod
@@ -107,9 +107,9 @@ P_obs (log(mst)-gam);
 Y_obs (gam);
 end;
 
-estimation(order=1, datafile=fsdat_simul, mode_compute=0,nobs=192, loglinear,diffuse_filter, smoother) m P c e W R k d n l gy_obs gp_obs y dA;
-estimation(order=1, datafile=fsdat_simul, mode_compute=0,nobs=192, loglinear,diffuse_filter, smoother,kalman_algo=3) m P c e W R k d n l gy_obs gp_obs y dA;
-estimation(order=1, datafile=fsdat_simul, mode_compute=0,nobs=192, loglinear,diffuse_filter, smoother,kalman_algo=4) m P c e W R k d n l gy_obs gp_obs y dA;
+estimation(order=1, datafile=fsdat_simul, mode_compute=0,nobs=192, loglinear,diffuse_filter, smoother,smoothed_state_uncertainty) m P c e W R k d n l gy_obs gp_obs y dA;
+estimation(order=1, datafile=fsdat_simul, mode_compute=0,nobs=192, loglinear,diffuse_filter, smoother,kalman_algo=3,smoothed_state_uncertainty) m P c e W R k d n l gy_obs gp_obs y dA;
+estimation(order=1, datafile=fsdat_simul, mode_compute=0,nobs=192, loglinear,diffuse_filter, smoother,kalman_algo=4,smoothed_state_uncertainty) m P c e W R k d n l gy_obs gp_obs y dA;
 
 /*
  * The following lines were used to generate the data file. If you want to


### PR DESCRIPTION
1. In case of missing observations ('if isempty(di)'), `a(:,t)` was not propagated forward to update `a(:,t+1)`
2. In the rank-deficient `Finf` case, `Kstar` was defined as `T^(-1)*K^{(0)}`, while in the full rank it was defined as `Kstar=K^(0)` This leads to wrong results when switches between the two clauses occurr. Moreover, the later backwards pass relied on `Kstar=K^(0)`, leading to wrong results when the rank-deficient `Finf` case was triggered earlier. 
3. In the rank-deficient `Finf` case, the backward pass did not use the proper formulas, but rather the ones for the non-singular case

The implementation now consistently follows the one in `kalman_filter_d.m`
