### PR TITLE
Fix bug in dyn_forecast.m that led to crashes when periods-option was…

### DIFF
--- a/matlab/dyn_forecast.m
+++ b/matlab/dyn_forecast.m
@@ -140,7 +140,7 @@ else
                             repmat(oo.exo_det_steady_state',...
                                    horizon- ... 
                                    exo_det_length,1)];
-    elseif horizon < exo_det_length 
+    elseif horizon <= exo_det_length 
         ex = zeros(exo_det_length,M.exo_nbr); 
     end
     if isequal(M.H,0)


### PR DESCRIPTION
… not specified

Condition for setting ex did not account for equality of horizon and periods. Affects only forecasting with exogenous deterministic variables.
