### PR TITLE
Remove unused exogenous variables from unit tests

### DIFF
--- a/tests/deterministic_simulations/multiple_lead_lags/AR2.mod
+++ b/tests/deterministic_simulations/multiple_lead_lags/AR2.mod
@@ -1,8 +1,5 @@
 var y_backward;
 
-// Exogenous variable: technology level
-varexo x;
-
 parameters rho_1 rho_2;
 
 rho_1=0.2;
@@ -28,13 +25,6 @@ end;
 
 // Check the Blanchard-Kahn conditions
 check;
-
-// Declare a positive technological shock in period 1
-shocks;
-var x;
-periods 1;
-values 1.2;
-end;
 
 // Deterministic simulation of the model for 200 periods
 options_.solve_tolf=1e-12;

--- a/tests/deterministic_simulations/multiple_lead_lags/AR2_forward.mod
+++ b/tests/deterministic_simulations/multiple_lead_lags/AR2_forward.mod
@@ -1,8 +1,5 @@
 var y_backward dummy_var;
 
-// Exogenous variable: technology level
-varexo x;
-
 parameters rho_1 rho_2;
 
 rho_1=0.2;
@@ -30,13 +27,6 @@ end;
 
 // Check the Blanchard-Kahn conditions
 check;
-
-// Declare a positive technological shock in period 1
-shocks;
-var x;
-periods 1;
-values 1.2;
-end;
 
 // Deterministic simulation of the model for 200 periods
 options_.solve_tolf=1e-12;

--- a/tests/estimation/fs2000_initialize_from_calib.mod
+++ b/tests/estimation/fs2000_initialize_from_calib.mod
@@ -1,6 +1,6 @@
 //uses a prior mean for bet that does not allow solving the model. Then uses the calibrated value to initialize.
 var m P c e W R k d n l gy_obs gp_obs y dA;
-varexo e_a e_m e_f;
+varexo e_a e_m;
 
 parameters alp bet gam mst rho psi del;
 
@@ -59,7 +59,6 @@ end;
 shocks;
 var e_a; stderr 0.014;
 var e_m; stderr 0.005;
-var e_f; stderr 0.0001;
 corr gy_obs, gp_obs = 0.1;
 var gy_obs; stderr 0.005;
 var gp_obs; stderr 0.005;


### PR DESCRIPTION
Related to #841 