### PR TITLE
FIX: JSON remove space before symbols + quote values

### DIFF
--- a/preprocessor/NumericalInitialization.cc
+++ b/preprocessor/NumericalInitialization.cc
@@ -66,9 +66,9 @@ InitParamStatement::writeJuliaOutput(ostream &output, const string &basename)
 void
 InitParamStatement::writeJsonOutput(ostream &output) const
 {
-  output << "{\"statementName\": \"param_init\", \"name\": \"" << symbol_table.getName(symb_id) << "\", " << "\"value\": ";
+  output << "{\"statementName\": \"param_init\", \"name\": \"" << symbol_table.getName(symb_id) << "\", " << "\"value\": \"";
   param_value->writeOutput(output);
-  output << "}";
+  output << "\"}";
 }
 
 void

--- a/preprocessor/SymbolTable.cc
+++ b/preprocessor/SymbolTable.cc
@@ -1025,9 +1025,9 @@ SymbolTable::writeJsonVarVector(ostream &output, const vector<int> &varvec) cons
   for (int i = 0; i < varvec.size(); i++)
     {
       output << endl << "{"
-             << "\"name\":\" " << getName(varvec[i]) << "\", "
-             << "\"texName\":\" " << boost::replace_all_copy(getTeXName(varvec[i]), "\\", "\\\\") << "\", "
-             << "\"longName\":\" " << boost::replace_all_copy(getLongName(varvec[i]), "\\", "\\\\") << "\"}";
+             << "\"name\":\"" << getName(varvec[i]) << "\", "
+             << "\"texName\":\"" << boost::replace_all_copy(getTeXName(varvec[i]), "\\", "\\\\") << "\", "
+             << "\"longName\":\"" << boost::replace_all_copy(getLongName(varvec[i]), "\\", "\\\\") << "\"}";
       if (i < varvec.size() - 1)
         output << ", ";
     }


### PR DESCRIPTION
This PR removes two bugs:

- Removes the space in the list of variables:
```
"endogenous":[
{"name":" y", "texName":"y", "longName":"y"}, 
{"name":" c", "texName":"c", "longName":"c"}, 
{"name":" k", "texName":"k", "longName":"k"}, 
{"name":" a", "texName":"a", "longName":"a"}, 
{"name":" h", "texName":"h", "longName":"h"}, 
{"name":" b", "texName":"b", "longName":"b"}
]
```
- Quotes values in param_init statements instead of:
```
{"statementName": "param_init", "name": "psi", "value": -(0.3+a)}
```