### PR TITLE
Store indicator whether smoother was used with loglinear

### DIFF
--- a/doc/dynare.texi
+++ b/doc/dynare.texi
@@ -6717,6 +6717,11 @@ Fields are of the form:
 @end example
 @end defvr
 
+@defvr {MATLAB/Octave variable} oo_.Smoother.loglinear
+Indicator keeping track of whether the smoother was run with the @ref{loglinear} option 
+and thus whether stored smoothed objects are in logs.
+@end defvr
+
 @defvr {MATLAB/Octave variable} oo_.PosteriorTheoreticalMoments
 @anchor{oo_.PosteriorTheoreticalMoments}
 Variable set by the @code{estimation} command, if it is used with the

--- a/matlab/prior_posterior_statistics.m
+++ b/matlab/prior_posterior_statistics.m
@@ -141,6 +141,11 @@ ifil = zeros(n_variables_to_fill,1);
 run_smoother = 0;
 if options_.smoother || options_.forecast || options_.filter_step_ahead || options_.smoothed_state_uncertainty
     run_smoother = 1;
+    if options_.loglinear
+        oo_.Smoother.loglinear=1;
+    else
+        oo_.Smoother.loglinear=0;
+    end
 end
 
 filter_covariance=0;

--- a/matlab/store_smoother_results.m
+++ b/matlab/store_smoother_results.m
@@ -76,6 +76,11 @@ if nargin<16
     Trend=zeros(options_.number_of_observed_variables,gend);
 end
 
+if options_.loglinear
+    oo_.Smoother.loglinear=1;
+else
+    oo_.Smoother.loglinear=0;
+end
 %% write variable steady state
 oo_.Smoother.SteadyState = ys;
 


### PR DESCRIPTION
Required to keep track of whether estimates were logged. Related to #1407