### PR TITLE
Make sure options_.first_obs is properly set

### DIFF
--- a/matlab/dynare_estimation_1.m
+++ b/matlab/dynare_estimation_1.m
@@ -44,6 +44,11 @@ end
 
 %store qz_criterium
 qz_criterium_old=options_.qz_criterium;
+if isnan(options_.first_obs)
+    first_obs_nan_indicator=true;
+else
+    first_obs_nan_indicator=false;
+end
 
 % Set particle filter flag.
 if options_.order > 1
@@ -775,4 +780,7 @@ options_.qz_criterium=qz_criterium_old;
 if reset_options_related_to_estimation
     options_.mode_compute = mode_compute_o;
     options_.mh_replic = mh_replic_o;
+end
+if first_obs_nan_indicator
+    options_.first_obs=NaN;
 end

--- a/matlab/dynare_estimation_init.m
+++ b/matlab/dynare_estimation_init.m
@@ -527,13 +527,16 @@ if ~isempty(options_.datafile)
     end
 end
 
+if isnan(options_.first_obs)
+    options_.first_obs=1;
+end
 [dataset_, dataset_info, newdatainterfaceflag] = makedataset(options_, options_.dsge_var*options_.dsge_varlag, gsa_flag);
 
 %set options for old interface from the ones for new interface
 if ~isempty(dataset_)
     options_.nobs = dataset_.nobs;
-    options_.first_obs=double(dataset_.init);
 end
+
 % setting steadystate_check_flag option
 if options_.diffuse_filter || options_.steadystate.nocheck
     steadystate_check_flag = 0;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -12,6 +12,7 @@ MODFILES = \
 	observation_trends_and_prefiltering/MCMC/Trend_loglin_prefilt_first_obs_MC.mod \
 	observation_trends_and_prefiltering/MCMC/Trend_prefilter_MC.mod \
 	observation_trends_and_prefiltering/MCMC/Trend_prefilter_first_obs_MC.mod \
+    dates/dseries_interact.mod \
 	estimation/slice/fs2000_slice.mod \
 	optimizers/fs2000_9.mod \
 	optimizers/fs2000_10.mod \

--- a/tests/dates/dseries_interact.mod
+++ b/tests/dates/dseries_interact.mod
@@ -1,0 +1,57 @@
+%% Mod-file tests interaction between estimation and shock_decomposition when dseries is used or not
+var hh nn log_nn;
+varexo eps_a;
+parameters alfa nbar lambda betta rho_a std_a nn_init;
+
+nn_init = -0.1;
+alfa = 0.05;
+lambda = 0.054;
+betta = 0.99;
+nbar = 1;
+rho_a = 0;
+std_a = 1;
+
+
+model(linear);
+
+hh = - alfa * nn + betta * ( hh(+1) + 0  *  eps_a(+1) ) + eps_a;
+
+log_nn = log_nn(-1) + hh * lambda / (1-lambda);
+
+log_nn = ln(nbar) + nn;
+
+end;
+
+steady_state_model;
+log_nn = log(nbar);
+nn = 0;
+hh = 0;
+end;
+
+shocks;
+var eps_a; stderr 1;
+end;
+
+estimated_params;
+alfa, beta_pdf,   0.1, 0.05; 
+std_a,   inv_gamma_pdf, 0.05, 1;
+end;
+
+varobs log_nn;
+
+if ~isoctave() && ~matlab_ver_less_than('8.4')
+   websave('data_uav.xlsx','http://www.dynare.org/Datasets/data_uav.xlsx', weboptions('Timeout', 30))
+else
+   urlwrite('http://www.dynare.org/Datasets/data_uav.xlsx','data_uav.xlsx')
+end
+
+%reading Excel sheet from column A on creates quarterly dseries starting in
+%1950
+estimation(first_obs=2,datafile=data_uav, xls_sheet=Tabelle1, xls_range=a1:b54, mh_replic=2, mh_nblocks=1, mh_jscale=1.1, mh_drop=0.8, plot_priors=0, smoother) log_nn nn hh ;
+shock_decomposition( parameter_set=posterior_median ) nn hh;
+
+%reading Excel sheet from column B on creates annual dseries starting with 1
+estimation(first_obs=2,datafile=data_uav, xls_sheet=Tabelle1, xls_range=b1:b54, mh_replic=2, mh_nblocks=1, mh_jscale=1.1, mh_drop=0.8, plot_priors=0, smoother) log_nn nn hh ;
+shock_decomposition( parameter_set=posterior_median ) nn hh;
+
+delete('data_uav.xlsx')


### PR DESCRIPTION
In ```dynare_estimation_1.m``` we restore compatibility with the old data interface via
```
%set options for old interface from the ones for new interface
if ~isempty(dataset_)
    options_.nobs = dataset_.nobs;
    options_.first_obs=double(dataset_.init);
end
```
This is problematic, because 
1. `options_` is global and `first_obs` is then not `NaN` anymore, affecting subsequent calls. A short solution would be to reset `options_.first_obs` at the end of the function, but I am not sure, this is the best solution.
2. The setting of `first_obs` does not correctly work if the data is a `dseries` that does not start with 1. To see the problem, consider a `dseries` dataset that starts in 1950Q1. `options_.first_obs.double(dataset_.init)` will then be 1950 instead of 1. This will for example invalidate the 
```
trend_addition=trend_coeff*[DynareOptions.first_obs:DynareOptions.first_obs+ntobs-1];
```
in `compute_trend_coefficients.m`, which relies on `first_obs` being an integer with observations starting at 1. 
3. `makedataset.m` contains the line
``` % Select a subsample.
DynareDataset = DynareDataset(FIRSTOBS:lastobs);
``` 
so we always cut the sample. But this implies that we lose all information on the first period originally contained in the dataset and therefore prevents recovering the implied `options_.first_obs` afterwards. Thus, we need to do it before calling `makedataset.m`. @stepan-a I am not sure how `makedataset` is intended to work, but it seems a solution might be to condition the setting of `first_obs=1` if NaN was encountered: 
``` 
if isnan(options_.first_obs)
    options_.first_obs=1;
end
[dataset_, dataset_info, newdatainterfaceflag] = makedataset(options_, options_.dsge_var*options_.dsge_varlag, gsa_flag);

%set options for old interface from the ones for new interface
if ~isempty(dataset_)
    options_.nobs = dataset_.nobs;
end
```

A subsequent call to `shock_decomposition,m` will call `evaluate_smoother.m`, which contains
```
persistent dataset_ dataset_info

if isempty(dataset_) || isempty(bayestopt_) || (options_.nobs ~= dataset_.nobs)
    [dataset_,dataset_info,xparam1, hh, M_, options_, oo_, estim_params_,bayestopt_] = dynare_estimation_init(var_list, M_.fname, [], M_, options_, oo_, estim_params_, bayestopt_);
else 
% set the qz_criterium
    options_=select_qz_criterium_value(options_);
end
```
There are two problems here.
5. I do not understand why we use persistent variables. This strikes me as error prone. We only build the dataset the first time or when `nobs` changes. But what if `nobs` does not change, but `first_obs` changes?
6. Upon entering `options_.first_obs` is not NaN anymore, but 1950. This causes trouble in `makedataset.m` where we have 
```
if isnan(DynareOptions.first_obs)
    firstobs = DynareDataset.init;
else
    firstobs = DynareDataset.dates(DynareOptions.first_obs);
end
```
We go to the `else` branch and try to select a dseries element. But element 1950 does not exist.

The attached commit seemingly fixes the issues except for the problem with `persistent`. The xlsx-file for the integration test is attached
[data_uav.xlsx](https://github.com/DynareTeam/dynare/files/856135/data_uav.xlsx)
