### PR TITLE
Test the rank of Pinf in univariate smoother for the subset of observables

### DIFF
--- a/matlab/DsgeSmoother.m
+++ b/matlab/DsgeSmoother.m
@@ -255,7 +255,9 @@ if kalman_algo == 2 || kalman_algo == 4
                     [Pstar,Pinf] = compute_Pinf_Pstar(mf,ST,R1,Q,options_.qz_criterium);
                 else
                     Pstar = blkdiag(Pstar,H);
-                    Pinf  = blkdiag(Pinf,zeros(vobs));                    
+                    if ~isempty(Pinf)
+                        Pinf  = blkdiag(Pinf,zeros(vobs));                    
+                    end
                 end
                 %now reset H to 0
                 H   = zeros(vobs,vobs);

--- a/matlab/missing_DiffuseKalmanSmootherH3_Z.m
+++ b/matlab/missing_DiffuseKalmanSmootherH3_Z.m
@@ -122,7 +122,7 @@ end
 
 t = 0;
 icc=0;
-newRank = rank(Pinf(:,:,1),diffuse_kalman_tol);
+newRank = rank(Z*Pinf(:,:,1)*Z',diffuse_kalman_tol);
 while newRank && t < smpl
     t = t+1;
     a(:,t) = a1(:,t);
@@ -156,7 +156,7 @@ while newRank && t < smpl
         end
     end
     if newRank
-        oldRank = rank(Pinf(:,:,t),diffuse_kalman_tol);
+        oldRank = rank(Z*Pinf(:,:,t)*Z',diffuse_kalman_tol);
     else
         oldRank = 0;
     end
@@ -168,7 +168,7 @@ while newRank && t < smpl
     Pstar(:,:,t+1) = T*Pstar(:,:,t)*T'+ QQ;
     Pinf(:,:,t+1) = T*Pinf(:,:,t)*T';
     if newRank
-        newRank       = rank(Pinf(:,:,t+1),diffuse_kalman_tol);
+        newRank       = rank(Z*Pinf(:,:,t+1)*Z',diffuse_kalman_tol);
     end
     if oldRank ~= newRank
         disp('univariate_diffuse_kalman_filter:: T does influence the rank of Pinf!')   
@@ -367,3 +367,9 @@ if decomp_flag
 end
 
 epsilonhat = Y - Z*alphahat;
+
+
+if (d==smpl)
+    warning(['missing_DiffuseKalmanSmootherH3_Z:: There isn''t enough information to estimate the initial conditions of the nonstationary variables']);    
+    return
+end

--- a/matlab/missing_DiffuseKalmanSmootherH3_Z.m
+++ b/matlab/missing_DiffuseKalmanSmootherH3_Z.m
@@ -122,7 +122,11 @@ end
 
 t = 0;
 icc=0;
-newRank = rank(Z*Pinf(:,:,1)*Z',diffuse_kalman_tol);
+if ~isempty(Pinf(:,:,1))
+    newRank = rank(Z*Pinf(:,:,1)*Z',diffuse_kalman_tol);
+else
+    newRank = rank(Pinf(:,:,1),diffuse_kalman_tol);
+end
 while newRank && t < smpl
     t = t+1;
     a(:,t) = a1(:,t);
@@ -156,7 +160,11 @@ while newRank && t < smpl
         end
     end
     if newRank
-        oldRank = rank(Z*Pinf(:,:,t)*Z',diffuse_kalman_tol);
+        if ~isempty(Pinf(:,:,t))
+            oldRank = rank(Z*Pinf(:,:,t)*Z',diffuse_kalman_tol);
+        else
+            oldRank = rank(Pinf(:,:,t),diffuse_kalman_tol);
+        end        
     else
         oldRank = 0;
     end
@@ -168,7 +176,11 @@ while newRank && t < smpl
     Pstar(:,:,t+1) = T*Pstar(:,:,t)*T'+ QQ;
     Pinf(:,:,t+1) = T*Pinf(:,:,t)*T';
     if newRank
-        newRank       = rank(Z*Pinf(:,:,t+1)*Z',diffuse_kalman_tol);
+        if ~isempty(Pinf(:,:,t+1))
+            newRank = rank(Z*Pinf(:,:,t+1)*Z',diffuse_kalman_tol);
+        else
+            newRank = rank(Pinf(:,:,t+1),diffuse_kalman_tol);
+        end
     end
     if oldRank ~= newRank
         disp('univariate_diffuse_kalman_filter:: T does influence the rank of Pinf!')   


### PR DESCRIPTION
Traps cases where this is not already trapped in compute_Pinf_Pstar.m
Supersedes and thus closes #1427 