### PR TITLE
Make resol.m honor nocheck flag

### DIFF
--- a/matlab/resol.m
+++ b/matlab/resol.m
@@ -101,7 +101,7 @@ if M.exo_nbr == 0
     oo.exo_steady_state = [] ;
 end
 
-[dr.ys,M.params,info] = evaluate_steady_state(oo.steady_state,M,options,oo,0);
+[dr.ys,M.params,info] = evaluate_steady_state(oo.steady_state,M,options,oo,~options.steadystate.nocheck);
 
 if info(1)
     oo.dr = dr;


### PR DESCRIPTION
Before, we never tested for correctness, allowing for wrong steady state files in the check command. Fixes bug introduced in 616efb53a448cfa59149951395838627fd1bf719 and restores behavior in 4.4.3