### PR TITLE
sim1_linear.m: Fix evaluation of dynamic model at deterministic stead…

### DIFF
--- a/matlab/perfect-foresight-models/sim1_linear.m
+++ b/matlab/perfect-foresight-models/sim1_linear.m
@@ -111,7 +111,8 @@ dynamicmodel = str2func([M.fname,'_dynamic']);
 z = steadystate_y([ip; ic; in]);
 
 % Evaluate the Jacobian of the dynamic model at the deterministic steady state.
-[d1,jacobian] = dynamicmodel(z, transpose(steadystate_x), params, steadystate_y, 1);
+[d1,jacobian] = dynamicmodel(z, repmat(transpose(steadystate_x),options.periods+M.maximum_lag+M.maximum_lead,1),...
+    params, steadystate_y, M.maximum_lag+1);
 
 % Check that the dynamic model was evaluated at the steady state.
 if max(abs(d1))>1e-12

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -179,6 +179,7 @@ MODFILES = \
 	simul/simul_ZLB_purely_forward.mod \
 	simul/simul_ZLB_purely_forward_no_solution.mod \
 	simul/Irreversible_investment.mod \
+	simul/linear_state_space_ARMA.mod \
 	conditional_forecasts/2/fs2000_est.mod \
 	conditional_forecasts/3/fs2000_conditional_forecast_initval.mod \
 	conditional_forecasts/4/fs2000_conditional_forecast_histval.mod \

--- a/tests/simul/linear_state_space_ARMA.mod
+++ b/tests/simul/linear_state_space_ARMA.mod
@@ -1,0 +1,43 @@
+%mod-file triggering the sim1_linear.m solver;
+%The exogenous arma processes test whether the Jacobian at the
+%deterministic steady state is correctly computed
+var x
+    y
+    z;
+
+varexo u
+       v;
+
+parameters a1 a2 a3 a4
+	   b1 b2 b3
+	   c1;
+
+a1 =  .50;
+a2 =  .00;
+a3 =  .70;
+a4 =  .40;
+b1 =  .90;
+b2 =  .00;
+b3 =  .80;
+c1 =  .95;
+
+
+model(linear);
+   y = a1*x(-1) + a2*x(+1) + a3*z + a4*y(-1);
+   z = b1*z(-1) + b2*z(+1) + b3*x + u;
+   x = c1*x(-1) + v +v(-1)+v(+1);
+end;
+
+initval;
+y=-1;
+x=-1;
+z=-1;
+end;
+
+endval;
+y=0;
+x=0;
+z=0;
+end;
+steady;
+simul(periods=1000,stack_solve_algo=0);


### PR DESCRIPTION
…y state

Did not correctly account for exogenous variables being potentially present with leads and lags

Related to https://forum.dynare.org/t/stack-solve-algo-0-reports-error/10488