### PR TITLE
Fix get_posterior_parameters

### DIFF
--- a/matlab/GetOneDraw.m
+++ b/matlab/GetOneDraw.m
@@ -1,10 +1,15 @@
-function [xparams, logpost] = GetOneDraw(type)
-% function [xparams, logpost] = GetOneDraw(type)
+function [xparams, logpost] = GetOneDraw(type,M_,estim_params_,oo_,options_,bayestopt_)
+% function [xparams, logpost] = GetOneDraw(type,M_,estim_params_,oo_,options_,bayestopt_)
 % draws one parameter vector and its posterior from MCMC or the prior
 %
 % INPUTS
 %    type:      [string]       'posterior': draw from MCMC draws
 %                              'prior': draw from prior
+%    M_         [structure]     Definition of the model
+%    estim_params_ [structure]  characterizing parameters to be estimated
+%    oo_         [structure]    Storage of results
+%    options_    [structure]    Options
+%    bayestopt_  [structure]    describing the priors
 %
 % OUTPUTS
 %    xparams:   vector of estimated parameters (drawn from posterior or prior distribution)
@@ -36,6 +41,6 @@ switch type
   case 'prior'
     xparams = prior_draw();
     if nargout>1
-        logpost = evaluate_posterior_kernel(xparams');
+        logpost = evaluate_posterior_kernel(xparams',M_,estim_params_,oo_,options_,bayestopt_);
     end
 end

--- a/matlab/PosteriorIRF.m
+++ b/matlab/PosteriorIRF.m
@@ -174,7 +174,7 @@ localVars.type=type;
 if strcmpi(type,'posterior')
     while b<B
         b = b + 1;
-        x(b,:) = GetOneDraw(type);
+        x(b,:) = GetOneDraw(type,M_,estim_params_,oo_,options_,bayestopt_);
     end
 end
 

--- a/matlab/PosteriorIRF_core1.m
+++ b/matlab/PosteriorIRF_core1.m
@@ -141,7 +141,7 @@ while fpar<B
     irun = irun+1;
     irun2 = irun2+1;
     if strcmpi(type,'prior')
-        deep = GetOneDraw(type);
+        deep = GetOneDraw(type,M_,estim_params_,oo_,options_,bayestopt_);
     else
         deep = x(fpar,:);
     end

--- a/matlab/dynare_estimation_1.m
+++ b/matlab/dynare_estimation_1.m
@@ -519,7 +519,7 @@ if (any(bayestopt_.pshape  >0 ) && options_.mh_replic) || ...
             end
             prior_posterior_statistics('posterior',dataset_,dataset_info);
         end
-        xparam1 = get_posterior_parameters('mean');
+        xparam1 = get_posterior_parameters('mean',M_,estim_params_,oo_,options_);
         M_ = set_all_parameters(xparam1,estim_params_,M_);
     end
 end

--- a/matlab/dynare_identification.m
+++ b/matlab/dynare_identification.m
@@ -271,15 +271,15 @@ if iload <=0
               case 'posterior_mode'
                 parameters_TeX = 'Posterior mode';
                 disp('Testing posterior mode')
-                params(1,:) = get_posterior_parameters('mode');
+                params(1,:) = get_posterior_parameters('mode',M_,estim_params_,oo_,options_);
               case 'posterior_mean'
                 parameters_TeX = 'Posterior mean';
                 disp('Testing posterior mean')
-                params(1,:) = get_posterior_parameters('mean');
+                params(1,:) = get_posterior_parameters('mean',M_,estim_params_,oo_,options_);
               case 'posterior_median'
                 parameters_TeX = 'Posterior median';
                 disp('Testing posterior median')
-                params(1,:) = get_posterior_parameters('median');
+                params(1,:) = get_posterior_parameters('median',M_,estim_params_,oo_,options_);
               case 'prior_mode'
                 parameters_TeX = 'Prior mode';
                 disp('Testing prior mode')

--- a/matlab/evaluate_likelihood.m
+++ b/matlab/evaluate_likelihood.m
@@ -1,10 +1,14 @@
-function [llik,parameters] = evaluate_likelihood(parameters)
+function [llik,parameters] = evaluate_likelihood(parameters,M_,estim_params_,oo_,options_,bayestopt_)
 % Evaluate the logged likelihood at parameters.
 %
 % INPUTS
 %    o parameters  a string ('posterior mode','posterior mean','posterior median','prior mode','prior mean') or a vector of values for
 %                  the (estimated) parameters of the model.
-%
+%    o M_          [structure]  Definition of the model
+%    o estim_params_ [structure] characterizing parameters to be estimated
+%    o oo_         [structure]  Storage of results
+%    o options_    [structure]  Options
+%    o bayestopt_  [structure]  describing the priors
 %
 % OUTPUTS
 %    o ldens       [double]  value of the sample logged density at parameters.
@@ -35,8 +39,6 @@ function [llik,parameters] = evaluate_likelihood(parameters)
 % You should have received a copy of the GNU General Public License
 % along with Dynare.  If not, see <http://www.gnu.org/licenses/>.
 
-global options_ M_ bayestopt_ oo_ estim_params_
-
 persistent dataset dataset_info
 
 if nargin==0
@@ -46,11 +48,11 @@ end
 if ischar(parameters)
     switch parameters
       case 'posterior mode'
-        parameters = get_posterior_parameters('mode');
+        parameters = get_posterior_parameters('mode',M_,estim_params_,oo_,options_);
       case 'posterior mean'
-        parameters = get_posterior_parameters('mean');
+        parameters = get_posterior_parameters('mean',M_,estim_params_,oo_,options_);
       case 'posterior median'
-        parameters = get_posterior_parameters('median');
+        parameters = get_posterior_parameters('median',M_,estim_params_,oo_,options_);
       case 'prior mode'
         parameters = bayestopt_.p5(:);
       case 'prior mean'
@@ -72,5 +74,5 @@ end
 options_=select_qz_criterium_value(options_);
 
 llik = -dsge_likelihood(parameters,dataset,dataset_info,options_,M_,estim_params_,bayestopt_,prior_bounds(bayestopt_,options_.prior_trunc),oo_);
-ldens = evaluate_prior(parameters);
+ldens = evaluate_prior(parameters,M_,estim_params_,oo_,options_,bayestopt_);
 llik = llik - ldens;

--- a/matlab/evaluate_posterior_kernel.m
+++ b/matlab/evaluate_posterior_kernel.m
@@ -1,10 +1,16 @@
-function lpkern = evaluate_posterior_kernel(parameters,llik)
-% Evaluate the prior density at parameters.
+function lpkern = evaluate_posterior_kernel(parameters,M_,estim_params_,oo_,options_,bayestopt_,llik)
+% Evaluate the evaluate_posterior_kernel at parameters.
 %
 % INPUTS
 %    o parameters  a string ('posterior mode','posterior mean','posterior median','prior mode','prior mean') or a vector of values for
 %                  the (estimated) parameters of the model.
-%
+%    o M_         [structure]     Definition of the model
+%    o estim_params_ [structure]  characterizing parameters to be estimated
+%    o oo_         [structure]    Storage of results
+%    o options_    [structure]    Options
+%    o bayestopt_  [structure]    describing the priors
+%    o llik        [double]       value of the logged likelihood if it
+%                                   should not be computed
 %
 % OUTPUTS
 %    o lpkern      [double]  value of the logged posterior kernel.
@@ -34,8 +40,8 @@ function lpkern = evaluate_posterior_kernel(parameters,llik)
 % You should have received a copy of the GNU General Public License
 % along with Dynare.  If not, see <http://www.gnu.org/licenses/>.
 
-[ldens,parameters] = evaluate_prior(parameters);
-if nargin==1
-    llik = evaluate_likelihood(parameters);
+[ldens,parameters] = evaluate_prior(parameters,M_,estim_params_,oo_,options_,bayestopt_);
+if nargin==6 %llik provided as an input
+    llik = evaluate_likelihood(parameters,M_,estim_params_,oo_,options_,bayestopt_);
 end
 lpkern = ldens+llik;

--- a/matlab/evaluate_prior.m
+++ b/matlab/evaluate_prior.m
@@ -1,9 +1,14 @@
-function [ldens,parameters] = evaluate_prior(parameters)
+function [ldens,parameters] = evaluate_prior(parameters,M_,estim_params_,oo_,options_,bayestopt_)
 % Evaluate the prior density at parameters.
 %
 % INPUTS
 %    o parameters  a string ('posterior mode','posterior mean','posterior median','prior mode','prior mean') or a vector of values for
 %                  the (estimated) parameters of the model.
+%    o M_          [structure]  Definition of the model
+%    o oo_         [structure]  Storage of results
+%    o options_    [structure]  Options
+%    o bayestopt_  [structure]  describing the priors
+%    o estim_params_ [structure] characterizing parameters to be estimated
 %
 %
 % OUTPUTS
@@ -33,8 +38,6 @@ function [ldens,parameters] = evaluate_prior(parameters)
 % You should have received a copy of the GNU General Public License
 % along with Dynare.  If not, see <http://www.gnu.org/licenses/>.
 
-global bayestopt_
-
 if nargin==0
     parameters = 'posterior mode';
 end
@@ -42,11 +45,11 @@ end
 if ischar(parameters)
     switch parameters
       case 'posterior mode'
-        parameters = get_posterior_parameters('mode');
+        parameters = get_posterior_parameters('mode',M_,estim_params_,oo_,options_);
       case 'posterior mean'
-        parameters = get_posterior_parameters('mean');
+        parameters = get_posterior_parameters('mean',M_,estim_params_,oo_,options_);
       case 'posterior median'
-        parameters = get_posterior_parameters('median');
+        parameters = get_posterior_parameters('median',M_,estim_params_,oo_,options_);
       case 'prior mode'
         parameters = bayestopt_.p5(:);
       case 'prior mean'

--- a/matlab/evaluate_smoother.m
+++ b/matlab/evaluate_smoother.m
@@ -73,13 +73,13 @@ end
 if ischar(parameters)
     switch parameters
       case 'posterior_mode'
-        parameters = get_posterior_parameters('mode');
+        parameters = get_posterior_parameters('mode',M_,estim_params_,oo_,options_);
       case 'posterior_mean'
-        parameters = get_posterior_parameters('mean');
+        parameters = get_posterior_parameters('mean',M_,estim_params_,oo_,options_);
       case 'posterior_median'
-        parameters = get_posterior_parameters('median');
+        parameters = get_posterior_parameters('median',M_,estim_params_,oo_,options_);
       case 'mle_mode'
-        parameters = get_posterior_parameters('mode','mle_');
+        parameters = get_posterior_parameters('mode',M_,estim_params_,oo_,options_,'mle_');
       case 'prior_mode'
         parameters = bayestopt_.p5(:);
       case 'prior_mean'

--- a/matlab/execute_prior_posterior_function.m
+++ b/matlab/execute_prior_posterior_function.m
@@ -68,11 +68,11 @@ else
 end
 
 %get draws for later use
-first_draw=GetOneDraw(type);
+first_draw=GetOneDraw(type,M_,estim_params_,oo_,options_,bayestopt_);
 parameter_mat=NaN(n_draws,length(first_draw));
 parameter_mat(1,:)=first_draw;
 for draw_iter=2:n_draws
-    parameter_mat(draw_iter,:) = GetOneDraw(type);
+    parameter_mat(draw_iter,:) = GetOneDraw(type,M_,estim_params_,oo_,options_,bayestopt_);
 end
 
 % get output size

--- a/matlab/get_all_parameters.m
+++ b/matlab/get_all_parameters.m
@@ -6,7 +6,7 @@ function xparam1=get_all_parameters(estim_params_,M_)
 % parameter values
 %
 % INPUTS
-%        estim_params_:  Dynare structure describing the estimated parameters.
+%    estim_params_:  Dynare structure describing the estimated parameters.
 %    M_:             Dynare structure describing the model.
 %
 % OUTPUTS

--- a/matlab/get_posterior_parameters.m
+++ b/matlab/get_posterior_parameters.m
@@ -1,11 +1,13 @@
-function xparam = get_posterior_parameters(type,field1)
+function xparam = get_posterior_parameters(type,M_,estim_params_,oo_,options_,field1)
 
-% function xparam = get_posterior_parameters(type)
+% function xparam = get_posterior_parameters(type,M_,estim_params_,oo_,options_,field1)
 % Selects (estimated) parameters (posterior mode or posterior mean).
 %
 % INPUTS
-%   o type       [char]     = 'mode' or 'mean'.
-%   o field_1    [char]     optional field like 'mle_'.
+%   o type              [char]     = 'mode' or 'mean'.
+%   o M_:               [structure] Dynare structure describing the model.
+%   o estim_params_:    [structure] Dynare structure describing the estimated parameters.
+%   o field_1           [char]     optional field like 'mle_'.
 %
 % OUTPUTS
 %   o xparam     vector of estimated parameters
@@ -30,9 +32,7 @@ function xparam = get_posterior_parameters(type,field1)
 % You should have received a copy of the GNU General Public License
 % along with Dynare.  If not, see <http://www.gnu.org/licenses/>.
 
-global estim_params_ oo_ options_ M_
-
-if nargin<2
+if nargin<6
     field1='posterior_';
 end
 nvx = estim_params_.nvx;
@@ -48,7 +48,6 @@ for i=1:nvx
     k1 = estim_params_.var_exo(i,1);
     name1 = deblank(M_.exo_names(k1,:));
     xparam(m) = oo_.([field1 type]).shocks_std.(name1);
-    M_.Sigma_e(k1,k1) = xparam(m)^2;
     m = m+1;
 end
 
@@ -65,8 +64,6 @@ for i=1:ncx
     name1 = deblank(M_.exo_names(k1,:));
     name2 = deblank(M_.exo_names(k2,:));
     xparam(m) = oo_.([field1 type]).shocks_corr.([name1 '_' name2]);
-    M_.Sigma_e(k1,k2) = xparam(m);
-    M_.Sigma_e(k2,k1) = xparam(m);
     m = m+1;
 end
 
@@ -84,10 +81,5 @@ FirstDeep = m;
 for i=1:np
     name1 = deblank(M_.param_names(estim_params_.param_vals(i,1),:));
     xparam(m) = oo_.([field1 type]).parameters.(name1);
-    %assignin('base',name1,xparam(m));% Useless with version 4 (except maybe for users)
     m = m+1;
-end
-
-if np
-    M_.params(estim_params_.param_vals(:,1)) = xparam(FirstDeep:end);
 end

--- a/matlab/imcforecast.m
+++ b/matlab/imcforecast.m
@@ -80,16 +80,16 @@ if estimated_model
     if ischar(options_cond_fcst.parameter_set)
         switch options_cond_fcst.parameter_set
           case 'posterior_mode'
-            xparam = get_posterior_parameters('mode');
+            xparam = get_posterior_parameters('mode',M_,estim_params_,oo_,options_);
             graph_title='Posterior Mode';
           case 'posterior_mean'
-            xparam = get_posterior_parameters('mean');
+            xparam = get_posterior_parameters('mean',M_,estim_params_,oo_,options_);
             graph_title='Posterior Mean';
           case 'posterior_median'
-            xparam = get_posterior_parameters('median');
+            xparam = get_posterior_parameters('median',M_,estim_params_,oo_,options_);
             graph_title='Posterior Median';
           case 'mle_mode'
-            xparam = get_posterior_parameters('mode','mle_');
+            xparam = get_posterior_parameters('mode',M_,estim_params_,oo_,options_,'mle_');
             graph_title='ML Mode';
           case 'prior_mode'
             xparam = bayestopt_.p5(:);

--- a/matlab/prior_posterior_statistics.m
+++ b/matlab/prior_posterior_statistics.m
@@ -226,7 +226,7 @@ if strcmpi(type,'posterior')
     else
         logpost=NaN(B,1);
         for b=1:B
-            [x(b,:), logpost(b)] = GetOneDraw(type);
+            [x(b,:), logpost(b)] = GetOneDraw(type,M_,estim_params_,oo_,options_,bayestopt_);
         end
     end
     localVars.logpost=logpost;

--- a/matlab/prior_posterior_statistics_core.m
+++ b/matlab/prior_posterior_statistics_core.m
@@ -190,14 +190,14 @@ end
 for b=fpar:B
     if strcmpi(type,'prior')
 
-        [deep, logpo] = GetOneDraw(type);
+        [deep, logpo] = GetOneDraw(type,M_,estim_params_,oo_,options_,bayestopt_);
 
     else
         deep = x(b,:);
         if strcmpi(type,'posterior')
             logpo = logpost(b);
         else
-            logpo = evaluate_posterior_kernel(deep');
+            logpo = evaluate_posterior_kernel(deep',M_,estim_params_,oo_,options_,bayestopt_);
         end
     end
     M_ = set_all_parameters(deep,estim_params_,M_);


### PR DESCRIPTION
Get rid of setting variables from the base workspace in the function, making the function read-only (as the name suggests)