### PR TITLE
Make isfile.m command work with Matlab versions before 9.1

### DIFF
--- a/matlab/missing/isfile/isfile.m
+++ b/matlab/missing/isfile/isfile.m
@@ -49,7 +49,7 @@ cellofstringflag = false;
 n = 1;
 a = false;
 
-if ~isoctave() && isstring(b) && length(b)>1 && isvector(b)
+if ~isoctave() && ~matlab_ver_less_than('9.1') && isstring(b) && length(b)>1 && isvector(b)
     n = length(b);
     stringarrayflag = true;
     a = false(size(b));


### PR DESCRIPTION
String array was only introduced in 9.1/R2016b. Closes #1541 