### PR TITLE
Make fast_realtime accept observation as input

### DIFF
--- a/doc/dynare.texi
+++ b/doc/dynare.texi
@@ -7544,9 +7544,11 @@ realtime shock decompositions are computed, @i{i.e.} for
 @anchor{save_realtime} Choose for which vintages to save the full realtime
 shock decomposition. Default: @math{0}.
 
-@item fast_realtime
+@item fast_realtime = @var{INTEGER}
 @anchor{fast_realtime} Runs the smoother only twice: once for the last in-sample 
-and once for the last out-of-sample data point. Default: not enabled.
+and once for the last out-of-sample data point, where the provided integer defines the last observation 
+(equivalent to @ref{nobs}). 
+Default: not enabled.
 
 @end table
 

--- a/preprocessor/DynareBison.yy
+++ b/preprocessor/DynareBison.yy
@@ -3096,7 +3096,7 @@ o_init_state : INIT_STATE EQUAL INT_NUMBER { driver.option_num("shock_decomp.ini
 o_shock_decomposition_presample : PRESAMPLE EQUAL INT_NUMBER { driver.option_num("shock_decomp.presample", $3); };
 o_shock_decomposition_forecast : FORECAST EQUAL INT_NUMBER { driver.option_num("shock_decomp.forecast", $3); };
 o_save_realtime : SAVE_REALTIME EQUAL vec_int { driver.option_vec_int("shock_decomp.save_realtime", $3); };
-o_fast_realtime : FAST_REALTIME { driver.option_num("shock_decomp.fast_realtime", "1"); };
+o_fast_realtime : FAST_REALTIME EQUAL INT_NUMBER { driver.option_num("shock_decomp.fast_realtime", $3); };
 o_nodisplay : NODISPLAY { driver.option_num("nodisplay","1"); };
 o_psd_nodisplay : NODISPLAY { driver.option_num("plot_shock_decomp.nodisplay","1"); };
 o_graph_format : GRAPH_FORMAT EQUAL allowed_graph_formats

--- a/tests/shock_decomposition/ls2003_plot.mod
+++ b/tests/shock_decomposition/ls2003_plot.mod
@@ -133,7 +133,7 @@ close all,
 
 
 // testing realtime decomposition with fast_realtime option
-realtime_shock_decomposition(fast_realtime);
+realtime_shock_decomposition(fast_realtime=75);
 
 collect_latex_files;
 if system(['pdflatex -halt-on-error -interaction=batchmode ' M_.fname '_TeX_binder.tex'])


### PR DESCRIPTION
Provides interface for solving #1579 
@rattoma I am not sure about the implementation on the Matlab side, because now the smoother is run on the provided value and the stored `nobs`.