### PR TITLE
Discretion: Added catch for infinities

### DIFF
--- a/matlab/discretionary_policy_engine.m
+++ b/matlab/discretionary_policy_engine.m
@@ -112,9 +112,9 @@ F1=F10;
 while 1
     iter=iter+1;
     P=SylvesterDoubling(W+beta*F1'*Q*F1,beta*H1',H1,discretion_tol,solve_maxit);
-    if any(any(isnan(P)))
+    if any(any(isnan(P))) || any(any(isinf(P))) 
         P=SylvesterHessenbergSchur(W+beta*F1'*Q*F1,beta*H1',H1);
-        if any(any(isnan(P)))
+        if any(any(isnan(P))) || any(any(isinf(P)))
             retcode=2;
             return
         end


### PR DESCRIPTION
Comment: A user provided a file in which the Sylvester equation solved using doubling can evaluate to inf. When Doubling fails, one can try the Hessenberg-Schur algorithm.