### PR TITLE
prior bounds: make sure that lower and upper bounds only affect mode-…

### DIFF
--- a/matlab/dynare_estimation_1.m
+++ b/matlab/dynare_estimation_1.m
@@ -422,6 +422,7 @@ end
 
 if (any(bayestopt_.pshape  >0 ) && options_.mh_replic) || ...
         (any(bayestopt_.pshape >0 ) && options_.load_mh_file)  %% not ML estimation
+    bounds = prior_bounds(bayestopt_, options_.prior_trunc); %reset bounds as lb and ub must only be operational during mode-finding
     outside_bound_pars=find(xparam1 < bounds.lb | xparam1 > bounds.ub);
     if ~isempty(outside_bound_pars)
         for ii=1:length(outside_bound_pars)

--- a/matlab/identification_analysis.m
+++ b/matlab/identification_analysis.m
@@ -155,7 +155,7 @@ if info(1)==0
             info = stoch_simul(char(options_.varobs));
             dataset_ = dseries(oo_.endo_simul(options_.varobs_id,100+1:end)',dates('1Q1'), options_.varobs);
             derivatives_info.no_DLIK=1;
-            %bounds = prior_bounds(bayestopt_, options_.prior_trunc);
+            bounds = prior_bounds(bayestopt_, options_.prior_trunc); %reset bounds as lb and ub must only be operational during mode-finding
             [fval,info,cost_flag,DLIK,AHess,ys,trend_coeff,M_,options_,bayestopt_,oo_] = dsge_likelihood(params',dataset_,dataset_info,options_,M_,estim_params_,bayestopt_,bounds,oo_,derivatives_info);
             %                 fval = DsgeLikelihood(xparam1,data_info,options_,M_,estim_params_,bayestopt_,oo_);
             options_.analytic_derivation = analytic_derivation;


### PR DESCRIPTION
…finding

https://github.com/DynareTeam/dynare/commit/99dbc8c74d0ecf4c7a610c4a394fd85028cf2741 introduced a bug by disabling the resetting of the prior bounds used for the MCMC. The manual clearly states the bounds are only operational during mode-finding, but not during MCMC (and therefore prior sampling)